### PR TITLE
Remove `g` flag from filterItems regexp

### DIFF
--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -283,7 +283,7 @@ class SectionedMultiSelect extends PureComponent {
 
     items.forEach((item) => {
       const parts = searchTerm.trim().split(/[[ \][)(\\/?\-:]+/)
-      const regex = new RegExp(`(${parts.join('|')})`, 'ig')
+      const regex = new RegExp(`(${parts.join('|')})`, 'i')
       if (regex.test(get(item, displayKey))) {
         filteredItems.push(item)
       }


### PR DESCRIPTION
**Problem**: 
Inconsistent items filtering.

**Solution**:
Remove global `g` flag from regex, since it perform multiple `test` on same instance and therefore accumulates internal `lastIndex` counter leading to false-negative tests (in this case each second valid `test` returns `false` instead). As I understand, `_filterItems` was copied from toystars/react-native-multiple-select repo where regex is cleared between `test` invocations (https://github.com/toystars/react-native-multiple-select/blob/785e94ceee71bf649393d5662a564b8998a4931a/lib/react-native-multi-select.js#L390)

_Stack Overflow [reference](https://stackoverflow.com/a/210077)_: 
> Ok, i see it now. The key to your problem is the use of the g (global match) flag: when this is specified for a regex, it will be set up such that it can be executed multiple times, beginning each time at the place where it left off last time. It keeps a "bookmark" of sorts in its lastIndex property...