### PR TITLE
Add setSelectedText prop + merge defaultProps.colors with props.colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ Props, there are lots.
 |selectedItems					| []						| array 		|the selected items |
 |onSelectedItemsChange	| 	| function	|function that runs when an item is toggled|
 |onSelectedItemObjectsChange  |   | function  |function that returns the selected items as their original objects instead of an array of ids |
-|onCancel  |   | function  |function that runs when the confirm button is pressed |
-|onConfirm  |   | function  |function that runs when the cancel button is pressed |
+|onCancel  |   | function  |function that runs when the cancel button is pressed |
+|onConfirm  |   | function  |function that runs when the confirm button is pressed |
 
 ### Options
 
@@ -209,6 +209,7 @@ Props, there are lots.
 |searchTextFontFamily |  Avenir / normal - 200       | object  |font family for the search input. Can be a regular style object |
 |confirmFontFamily    |  Avenir / normal - bold      | object  |font family for the confirm button. |
 |numberOfLines        |null              |number     |numberOfLines for label text |  
+|labelNumberOfLines        |null              |number     |Number of lines for Selected Text label |  
 
 ## Colors
 You can pass a colors object to theme it how you like.

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ Props, there are lots.
 |selectText             |'Select'       | string    |the text for the select component |
 |confirmText            |'Confirm'      | string    |the text for the confirm button|
 |selectedText            |'selected'      | string OR function    |the text that follows the number of items selected |
+|setSelectedText            |      | function    | Function that allows you to set custom Selected Text given access to component's `props` |
 |searchPlaceholderText  |'Search categories...'| string   |the placeholder text for the search input |
 |searchAdornment |   | |function | receives search input text and is output on the right side of the search input |
 |removeAllText  |'Remove all'| string   |Text for optional remove all button |

--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -95,6 +95,21 @@ const styles = {
   },
 }
 
+const colors = {
+  primary: '#3f51b5',
+  success: '#4caf50',
+  cancel: '#1A1A1A',
+  text: '#2e2e2e',
+  subText: '#848787',
+  selectToggleTextColor: '#333',
+  searchPlaceholderTextColor: '#999',
+  searchSelectionColor: 'rgba(0,0,0,0.2)',
+  chipColor: '#848787',
+  itemBackground: '#fff',
+  subItemBackground: '#ffffff',
+  disabled: '#d7d7d7',
+}
+
 // let date = new Date()
 
 const noResults = <Text>Sorry, no results</Text>
@@ -122,6 +137,7 @@ class SectionedMultiSelect extends PureComponent {
       PropTypes.string,
       PropTypes.func
     ]),
+    setSelectedText: PropTypes.func,
     confirmText: PropTypes.string,
     styles: PropTypes.oneOfType([
       PropTypes.array,
@@ -176,20 +192,7 @@ class SectionedMultiSelect extends PureComponent {
     noResultsComponent: noResults,
     loadingComponent: loading,
     styles: {},
-    colors: {
-      primary: '#3f51b5',
-      success: '#4caf50',
-      cancel: '#1A1A1A',
-      text: '#2e2e2e',
-      subText: '#848787',
-      selectToggleTextColor: '#333',
-      searchPlaceholderTextColor: '#999',
-      searchSelectionColor: 'rgba(0,0,0,0.2)',
-      chipColor: '#848787',
-      itemBackground: '#fff',
-      subItemBackground: '#ffffff',
-      disabled: '#d7d7d7',
-    },
+    colors: {},
     itemFontFamily: { fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir', fontWeight: 'bold' },
     subItemFontFamily: { fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir', fontWeight: '200' },
     searchTextFontFamily: { fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir', fontWeight: '200' },
@@ -201,11 +204,10 @@ class SectionedMultiSelect extends PureComponent {
     hideSearch: false,
     selectChildren: false,
     highlightChildren: false,
-    numberOfLines: null,
+    numberOfLines: 1,
     showCancelButton: false,
     hideSelect: false,
     alwaysShowSelectText: false,
-    expandDropDowns: false,
 
   }
 
@@ -222,6 +224,7 @@ class SectionedMultiSelect extends PureComponent {
       highlightedChildren: [],
     }
     this.styles = StyleSheet.flatten([styles, props.styles])
+    this.colors = StyleSheet.flatten([colors, props.colors])
   }
 
   componentDidMount() {
@@ -273,7 +276,12 @@ class SectionedMultiSelect extends PureComponent {
       selectedItems,
       displayKey,
       alwaysShowSelectText,
+      setSelectedText,
     } = this.props
+
+    if (setSelectedText) {
+      return setSelectedText(this.props)
+    }
 
     if (!single && alwaysShowSelectText) {
       return selectText
@@ -611,7 +619,6 @@ class SectionedMultiSelect extends PureComponent {
     const {
       uniqueKey,
       selectedItems,
-      colors,
       displayKey,
     } = this.props
 
@@ -627,7 +634,7 @@ class SectionedMultiSelect extends PureComponent {
             overflow: 'hidden',
             justifyContent: 'center',
             height: 34,
-            borderColor: colors.chipColor,
+            borderColor: this.colors.chipColor,
             borderWidth: 1,
             borderRadius: 20,
             flexDirection: 'row',
@@ -644,7 +651,7 @@ class SectionedMultiSelect extends PureComponent {
             numberOfLines={1}
             style={[
               {
-                color: colors.chipColor,
+                color: this.colors.chipColor,
                 fontSize: 13,
                 marginRight: 0,
               },
@@ -662,7 +669,7 @@ class SectionedMultiSelect extends PureComponent {
             <Icon
               name="close"
               style={[{
-                color: colors.chipColor,
+                color: this.colors.chipColor,
                 fontSize: 16,
                 marginHorizontal: 6,
                 marginVertical: 7,
@@ -757,7 +764,6 @@ class SectionedMultiSelect extends PureComponent {
       loadingComponent,
       searchTextFontFamily,
       confirmFontFamily,
-      colors,
       single,
       showChips,
       removeAllText,
@@ -772,6 +778,7 @@ class SectionedMultiSelect extends PureComponent {
       hideSelect,
       headerComponent,
       searchAdornment,
+      numberOfLines,
     } = this.props
 
     const { searchTerm, selector } = this.state
@@ -812,11 +819,11 @@ class SectionedMultiSelect extends PureComponent {
                   />}
                 </View>
                 <TextInput
-                  selectionColor={colors.searchSelectionColor}
+                  selectionColor={this.colors.searchSelectionColor}
                   onChangeText={searchTerm => this.setState({ searchTerm })}
                   placeholder={searchPlaceholderText}
                   selectTextOnFocus
-                  placeholderTextColor={colors.searchPlaceholderTextColor}
+                  placeholderTextColor={this.colors.searchPlaceholderTextColor}
                   underlineColorAndroid="transparent"
                   style={[{
                       flex: 1,
@@ -875,7 +882,7 @@ class SectionedMultiSelect extends PureComponent {
                       paddingHorizontal: 16,
                       borderRadius: 0,
                       flexDirection: 'row',
-                      backgroundColor: colors.cancel,
+                      backgroundColor: this.colors.cancel,
                     },
                     this.styles.cancelButton,
                     ]}
@@ -905,7 +912,7 @@ class SectionedMultiSelect extends PureComponent {
                       paddingHorizontal: 16,
                       borderRadius: 0,
                       flexDirection: 'row',
-                      backgroundColor: colors.primary,
+                      backgroundColor: this.colors.primary,
                     },
                     this.styles.button,
                     ]}
@@ -929,11 +936,11 @@ class SectionedMultiSelect extends PureComponent {
             }, this.styles.selectToggle]}
           >
             <Text
-              numberOfLines={1}
+              numberOfLines={numberOfLines}
               style={[{
                 flex: 1,
                 fontSize: 16,
-                color: colors.selectToggleTextColor,
+                color: this.colors.selectToggleTextColor,
               }, this.styles.selectToggleText]}
             >
               {this._getSelectLabel()}
@@ -944,7 +951,7 @@ class SectionedMultiSelect extends PureComponent {
               <Icon
                 size={24}
                 name="keyboard-arrow-down"
-                style={{ color: colors.selectToggleTextColor }}
+                style={{ color: this.colors.selectToggleTextColor }}
               />}
           </View>
         </TouchableWithoutFeedback>
@@ -965,7 +972,7 @@ class SectionedMultiSelect extends PureComponent {
                   overflow: 'hidden',
                   justifyContent: 'center',
                   height: 34,
-                  borderColor: colors.chipColor,
+                  borderColor: this.colors.chipColor,
                   flexDirection: 'row',
                   alignItems: 'center',
                   paddingLeft: 10,
@@ -987,7 +994,7 @@ class SectionedMultiSelect extends PureComponent {
                     <Text
                       style={[
                         {
-                          color: colors.chipColor,
+                          color: this.colors.chipColor,
                           fontSize: 13,
                           marginRight: 0,
                         },

--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -167,6 +167,7 @@ class SectionedMultiSelect extends PureComponent {
     highlightChildren: PropTypes.bool,
     onSelectedItemObjectsChange: PropTypes.func,
     numberOfLines: PropTypes.number,
+    labelNumberOfLines: PropTypes.number,
     showCancelButton: PropTypes.bool,
     hideSelect: PropTypes.bool,
     onConfirm: PropTypes.func,
@@ -204,7 +205,8 @@ class SectionedMultiSelect extends PureComponent {
     hideSearch: false,
     selectChildren: false,
     highlightChildren: false,
-    numberOfLines: 1,
+    numberOfLines: null,
+    labelNumberOfLines: null,
     showCancelButton: false,
     hideSelect: false,
     alwaysShowSelectText: false,
@@ -778,7 +780,7 @@ class SectionedMultiSelect extends PureComponent {
       hideSelect,
       headerComponent,
       searchAdornment,
-      numberOfLines,
+      labelNumberOfLines,
     } = this.props
 
     const { searchTerm, selector } = this.state
@@ -936,7 +938,7 @@ class SectionedMultiSelect extends PureComponent {
             }, this.styles.selectToggle]}
           >
             <Text
-              numberOfLines={numberOfLines}
+              numberOfLines={labelNumberOfLines}
               style={[{
                 flex: 1,
                 fontSize: 16,


### PR DESCRIPTION
*  Merge `component.defaultProps.colors` with `props.colors`. From now on `colors` will work the same way as `styles` - there will be no need to redefine all colors if you only want to change one of them.
* `setSelectedText` - the function that gives a user access to component `props`, so that he can define his own way of rendering the Selected Text.
* Update Readme.MD
Example:
```
selectText="I speak"
numberOfLines={4}
setSelectedText={(msProps) => {
    return `${msProps.selectText} ${msProps.selectedItems.join(', ')}`;
}}
```
will produce a result like that:
![image](https://user-images.githubusercontent.com/8733843/40985001-b59b9bdc-6915-11e8-8886-f0d69df4db8a.png)
