### PR TITLE
add caption selecttext when option is selected

### DIFF
--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -95,6 +95,12 @@ const defaultStyles = {
   selectedItem: {
 
   },
+  selectTextCaption:{
+
+  },
+  viewSelector:{
+
+  },
 }
 
 
@@ -210,7 +216,8 @@ class SectionedMultiSelect extends PureComponent {
     chipsPosition: PropTypes.oneOf(['top', 'bottom']),
     autoFocus: PropTypes.bool,
     iconKey: PropTypes.string,
-    disabled: PropTypes.bool
+    disabled: PropTypes.bool,
+    showSelectTextCaption: PropTypes.bool
   }
 
   static defaultProps = {
@@ -254,7 +261,8 @@ class SectionedMultiSelect extends PureComponent {
     noItemsComponent: noItems,
     chipsPosition: 'bottom',
     autoFocus: false,
-    disabled: false
+    disabled: false,
+    showSelectTextCaption: false
   }
 
   constructor(props) {
@@ -898,7 +906,9 @@ class SectionedMultiSelect extends PureComponent {
       stickyFooterComponent,
       chipsPosition,
       autoFocus,
-      disabled
+      disabled,
+      selectText,
+      showSelectTextCaption
     } = this.props
 
     const {
@@ -911,7 +921,7 @@ class SectionedMultiSelect extends PureComponent {
     const confirmFont = confirmFontFamily.fontFamily && confirmFontFamily
     const searchTextFont = searchTextFontFamily.fontFamily && searchTextFontFamily
     return (
-      <View>
+      <View style={styles.viewSelector}>
         <Modal
           supportedOrientations={modalSupportedOrientations}
           animationType={modalAnimationType}
@@ -1080,6 +1090,13 @@ class SectionedMultiSelect extends PureComponent {
               >
                 {this._getSelectLabel()}
               </Text>
+              {(selectedItems.length === 1 && showSelectTextCaption) && 
+              <Text style={[{
+                  fontSize: 12,
+                  color: '#333'
+               }, styles.selectTextCaption]}>
+                {selectText}
+              </Text>}
               {selectToggleIconComponent ?
                 selectToggleIconComponent
                 :


### PR DESCRIPTION
When single is true, and the user selects a value, the selecttext prop is no longer displayed. The user can no longer know the name of the selectbox.
I added the props below:
- showSelectTextCaption (false by default) to show or hide caption when option is selected.
- selectTextCaption (style) to define custom style for the caption

On the other hand I also added "viewSelector" style to have the be able to stylize the view which includes the selector. I wanted to add flex: 0.5 on it but I could not.
<img width="387" alt="caption2" src="https://user-images.githubusercontent.com/49676829/56724080-982f7a80-674a-11e9-99cd-57f04362a46c.png">
