### PR TITLE
Update RowSubItem for 'iconRenderer' and 'iconKey' usage

### DIFF
--- a/lib/components/RowSubItem.js
+++ b/lib/components/RowSubItem.js
@@ -90,6 +90,7 @@ class RowSubItem extends Component {
       itemNumberOfLines,
       displayKey,
       iconKey,
+        iconRenderer: Icon,
     } = this.props
 
     const highlightChild = !selectChildren && highlightedChildren.includes(subItem[uniqueKey])
@@ -123,11 +124,12 @@ class RowSubItem extends Component {
           {selectedIconOnLeft && this._renderSelectedIcon()}
 
           {iconKey && subItem[iconKey] && (
-            <ItemIcon
-              iconKey={iconKey}
-              icon={subItem[iconKey]}
-              style={mergedStyles.itemIconStyle}
-            />
+              <ItemIcon
+                  iconRenderer={Icon}
+                  iconKey={iconKey}
+                  icon={subItem[iconKey]}
+                  style={mergedStyles.itemIconStyle}
+              />
           )}
           <Text
             numberOfLines={itemNumberOfLines}


### PR DESCRIPTION
Fix usage of subitem icon