### PR TITLE
Fix icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0 - 2020-09-30
+## 0.8.0 - 2020-10-01
 
 ### Fixed
 
@@ -8,11 +8,11 @@
 
 ### Added
 
-- the `icons` prop is an object that maps the names and sizes used for the icons. In conjunction with `IconRenderer` you can now easily switch out the icon library. See Icons section of Readme.
+- the `icons` prop is an object that maps the names and sizes used for the icons (all properties are spread onto the `IconRenderer`). In conjunction with `IconRenderer` you can now easily switch out the icon library. See Icons section of Readme.
 
 ### Changed
 
-- BREAKING: `IconRenderer` is now required (also note the casing change). The lib no longer relies on `react-native-vector-icons`. For the default Material Icons icon set, you must import Icon from `react-native-vector-icons/MaterialIcons` yourself, and pass that to the`IconRenderer` prop. See Icons section of Readme.
+- BREAKING: `IconRenderer` is now required (also note the casing change). The lib no longer depends on `react-native-vector-icons`. For the default Material Icons icon set, you must import Icon from `react-native-vector-icons/MaterialIcons` yourself, and pass that to the`IconRenderer` prop. See Icons section of Readme.
 
 ## 0.7.8 - 2020-09-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.8.0 - 2020-09-30
+
+### Fixed
+
+- 0.7.8 introduced a bug with an attempted fix of the iconRenderer. This update addresses that and icons in general.
+
+### Added
+
+- the `icons` prop is an object that maps the names and sizes used for the icons. In conjunction with `IconRenderer` you can now easily switch out the icon library. See Icons section of Readme.
+
+### Changed
+
+- BREAKING: `IconRenderer` is now required (also note the casing change). The lib no longer relies on `react-native-vector-icons`. For the default Material Icons icon set, you must import Icon from 'react-native-vector-icons/MaterialIcons`yourself, and pass that to the`IconRenderer` prop. See Icons section of Readme.
+
 ## 0.7.8 - 2020-09-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Changed
 
-- BREAKING: `IconRenderer` is now required (also note the casing change). The lib no longer relies on `react-native-vector-icons`. For the default Material Icons icon set, you must import Icon from 'react-native-vector-icons/MaterialIcons`yourself, and pass that to the`IconRenderer` prop. See Icons section of Readme.
+- BREAKING: `IconRenderer` is now required (also note the casing change). The lib no longer relies on `react-native-vector-icons`. For the default Material Icons icon set, you must import Icon from `react-native-vector-icons/MaterialIcons` yourself, and pass that to the`IconRenderer` prop. See Icons section of Readme.
 
 ## 0.7.8 - 2020-09-25
 

--- a/README.md
+++ b/README.md
@@ -45,35 +45,41 @@ See an example here: https://github.com/renrizzolo/react-native-sectioned-multi-
 
 ### icons prop
 
-You can now pass your own `icons` object to map the names (and sizes) to a different icon library or your own `IconRenderer` function.
-For each of these keys, the IconRenderer will be called with the corresponding `name` and `size`.
-Here is the default icons object, which uses the material icons names.
+You can now pass your own `icons` object to map the properties to a different icon library or your own `IconRenderer` component.
+For each of these keys, the `IconRenderer` will be called with the corresponding `name` and `size` props.
+All properties are spread to the `IconRenderer`, so you can override style or other props your icon component might use.
+
+Here is the default icons object, which uses Material Icons names.
 
 ```
 icons: {
   search: {
-    name: 'search',
+    name: 'search', // search input
     size: 24
   },
   arrowUp: {
-    name: 'keyboard-arrow-up',
-    size: 16
-  },
-  arrowDown: {
-    name: 'keyboard-arrow-down',
-    size: 16
-  },
-  close: {
-    name: 'close',
+    name: 'keyboard-arrow-up', // dropdown toggle
     size: 22
   },
+  arrowDown: {
+    name: 'keyboard-arrow-down', // dropdown toggle
+    size: 22
+  },
+  selectArrowDown: {
+    name: 'keyboard-arrow-down', // select
+    size: 24
+  },
+  close: {
+    name: 'close', // chip close
+    size: 16
+  },
   check: {
-    name: 'check',
+    name: 'check', // selected item
     size: 16
   },
   cancel: {
-    name: 'cancel',
-    size: 16
+    name: 'cancel', // cancel button
+    size: 18
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # react-native-sectioned-multi-select
 
+Hi, there's a breaking change in v0.8.0, I chose not to release a major version for various reasons. Please see [Icons](#icons). In short, you must pass `Icon` (from `react-native-vector-icons`, or any icon lib) to the `IconRenderer` prop now.
+
 [![NPM Version](https://img.shields.io/npm/v/react-native-sectioned-multi-select.svg?style=flat)](https://www.npmjs.com/package/react-native-sectioned-multi-select)
 
 A multi (or single) select component with support for sub categories, search, chips.
@@ -27,23 +29,68 @@ You can install this package with the following command:
 
 ### Icons
 
-By default, the library uses React Native Vector Icons Material Icons.
-Before installing, please make sure you have [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) set up.
+The library uses icon names from `react-native-vector-icons/MaterialIcons`, however, it no longer imports the `react-native-vector-icons` library.
+You should install [react-native-vector-icons](https://github.com/oblador/react-native-vector-icons) yourself, then pass the icon to the `IconRenderer` prop.
 
-If you prefer to use your own icon images or icon font, the `iconRenderer` prop can be used to replace the icons used.
+```
+import Icon from 'react-native-vector-icons/MaterialIcons`
+
+...
+
+<SectionedMultiSelect IconRenderer={Icon} />
+```
+
+If you prefer to use your own icon images or icon font, the `IconRenderer` prop can be used to replace the icons used.
 See an example here: https://github.com/renrizzolo/react-native-sectioned-multi-select/blob/9c5f71852aef7a7ac03e7761d5dd810cd2ccef5d/exampleapp/App.js#L322-L397 (note the switch, you can refer to this to know what to map icon names to e.g if you're just passing in a different RN Vector Icons font).
+
+### icons prop
+
+You can now pass your own `icons` object to map the names (and sizes) to a different icon library or your own `IconRenderer` function.
+For each of these keys, the IconRenderer will be called with the corresponding `name` and `size`.
+Here is the default icons object, which uses the material icons names.
+
+```
+icons: {
+  search: {
+    name: 'search',
+    size: 24
+  },
+  arrowUp: {
+    name: 'keyboard-arrow-up',
+    size: 16
+  },
+  arrowDown: {
+    name: 'keyboard-arrow-down',
+    size: 16
+  },
+  close: {
+    name: 'close',
+    size: 22
+  },
+  check: {
+    name: 'check',
+    size: 16
+  },
+  cancel: {
+    name: 'cancel',
+    size: 16
+  }
+}
+```
 
 ### Required props:
 
 `items` | array  
 `uniqueKey` | string  
 `onSelectedItemsChange` | function
+`IconRenderer` | function or object
 
 ### Basic Example
 
 ```javascript
 import React, { Component } from 'react';
 import { View } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialIcons`
 import SectionedMultiSelect from 'react-native-sectioned-multi-select';
 
 const items = [
@@ -102,6 +149,7 @@ export default class App extends Component {
       <View>
         <SectionedMultiSelect
           items={items}
+          IconRenderer={Icon}
           uniqueKey="id"
           subKey="children"
           selectText="Choose some things..."
@@ -152,7 +200,6 @@ You can also pass in extra options to individual items:
 
 - `disabled: true` - the item will be disabled
 - Icons: the component prop `iconKey` is the name of the property that individual item icons will be derived from. E.g `icon: {uri: ...}`. See full example [here](https://github.com/renrizzolo/react-native-sectioned-multi-select/blob/master/Recipes.md#item-icons)
-
 
 ## Props
 
@@ -235,7 +282,7 @@ Props, there are lots.
 | itemNumberOfLines               | null                           | number             | numberOfLines for item text                                                                                                                          |
 | selectLabelNumberOfLines        | 1                              | number             | numberOfLines for select label text                                                                                                                  |
 | customLayoutAnimation           | easeInEaseOut                  | object             | define your own `LayoutAnimation` preset or custom animation                                                                                         |
-| iconRenderer                    |                                | function OR object | Use your own icon component function. Receives name, size (in some cases), and style props                                                           |
+| IconRenderer                    |                                | function OR object | The icon component to use. Receives name, size (in some cases), and style props                                                                      |
 | itemsFlatListProps              | {}                             | object             | extra props to add to / override the FlatList of parent items                                                                                        |
 | subItemsFlatListProps           | {}                             | object             | extra props to add to / override the parent items' sub items FlatList                                                                                |
 

--- a/exampleapp/App.js
+++ b/exampleapp/App.js
@@ -11,10 +11,10 @@ import {
   ActivityIndicator,
   Dimensions,
   LayoutAnimation,
-  Image,
+  Image
 } from 'react-native'
 import SectionedMultiSelect from 'react-native-sectioned-multi-select'
-// import Icon from 'react-native-vector-icons/MaterialIcons'
+import Icon from 'react-native-vector-icons/MaterialIcons'
 
 const img = require('./z.jpg')
 
@@ -28,61 +28,61 @@ const items = [
     children: [
       {
         title: 'Apple',
-        id: 10,
+        id: 10
       },
       {
         title: 'Strawberry',
-        id: 11,
+        id: 11
       },
       {
         title: 'Pineapple',
-        id: 13,
+        id: 13
       },
       {
         title: 'Banana',
-        id: 14,
+        id: 14
       },
       {
         title: 'Wátermelon',
-        id: 15,
+        id: 15
       },
       {
         title: 'אבטיח',
-        id: 17,
+        id: 17
       },
       {
         title: 'Raspberry',
-        id: 18,
+        id: 18
       },
       {
         title: 'Orange',
-        id: 19,
+        id: 19
       },
       {
         title: 'Mandarin',
-        id: 20,
+        id: 20
       },
       {
         title: 'Papaya',
-        id: 21,
+        id: 21
       },
       {
         title: 'Lychee',
-        id: 22,
+        id: 22
       },
       {
         title: 'Cherry',
-        id: 23,
+        id: 23
       },
       {
         title: 'Peach',
-        id: 24,
+        id: 24
       },
       {
         title: 'Apricot',
-        id: 25,
-      },
-    ],
+        id: 25
+      }
+    ]
   },
   {
     title: 'Gèms',
@@ -91,21 +91,21 @@ const items = [
     children: [
       {
         title: 'Quartz',
-        id: 26,
+        id: 26
       },
       {
         title: 'Zircon',
-        id: 27,
+        id: 27
       },
       {
         title: 'Sapphirè',
-        id: 28,
+        id: 28
       },
       {
         title: 'Topaz',
-        id: 29,
-      },
-    ],
+        id: 29
+      }
+    ]
   },
   {
     title: 'Plants',
@@ -115,26 +115,26 @@ const items = [
     children: [
       {
         title: "Mother In Law's Tongue",
-        id: 30,
+        id: 30
       },
       {
         title: 'Yucca',
-        id: 31,
+        id: 31
       },
       {
         title: 'Monsteria',
-        id: 32,
+        id: 32
       },
       {
         title: 'Palm',
-        id: 33,
-      },
-    ],
+        id: 33
+      }
+    ]
   },
   {
     title: 'No child',
-    id: 34,
-  },
+    id: 34
+  }
 ]
 console.log(items)
 
@@ -170,17 +170,17 @@ for (let i = 0; i < 100; i++) {
     children: [
       {
         id: `10${i}`,
-        title: `child 10${i}`,
+        title: `child 10${i}`
       },
       {
         id: `11${i}`,
-        title: `child 11${i}`,
+        title: `child 11${i}`
       },
       {
         id: `12${i}`,
-        title: `child 12${i}`,
-      },
-    ],
+        title: `child 12${i}`
+      }
+    ]
   })
 }
 
@@ -189,38 +189,38 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
-    marginTop: 30,
+    marginTop: 30
   },
   container: {
     paddingTop: 40,
-    paddingHorizontal: 20,
+    paddingHorizontal: 20
   },
   welcome: {
     fontSize: 20,
     textAlign: 'center',
     margin: 10,
-    color: '#333',
+    color: '#333'
   },
   border: {
     borderBottomWidth: 1,
     borderBottomColor: '#dadada',
-    marginBottom: 20,
+    marginBottom: 20
   },
   heading: {
     fontSize: 24,
     fontWeight: 'bold',
     marginBottom: 5,
-    marginTop: 20,
+    marginTop: 20
   },
   label: {
-    fontWeight: 'bold',
+    fontWeight: 'bold'
   },
   switch: {
     marginBottom: 20,
     flexDirection: 'row',
     alignItems: 'flex-end',
-    justifyContent: 'space-between',
-  },
+    justifyContent: 'space-between'
+  }
 })
 const accentMap = {
   â: 'a',
@@ -260,11 +260,11 @@ const accentMap = {
   ù: 'u',
   Ù: 'U',
   ç: 'c',
-  Ç: 'C',
+  Ç: 'C'
 }
 const tintColor = '#174A87'
 
-const Loading = (props) =>
+const Loading = props =>
   props.hasErrored ? (
     <TouchableWithoutFeedback onPress={props.fetchCategories}>
       <View style={styles.center}>
@@ -272,18 +272,20 @@ const Loading = (props) =>
       </View>
     </TouchableWithoutFeedback>
   ) : (
-      <View style={styles.center}>
-        <ActivityIndicator size="large" />
-      </View>
-    )
+    <View style={styles.center}>
+      <ActivityIndicator size="large" />
+    </View>
+  )
 
-const Toggle = (props) => (
-  <TouchableWithoutFeedback onPress={() => props.onPress(!props.val)} disabled={props.disabled}>
+const Toggle = props => (
+  <TouchableWithoutFeedback
+    onPress={() => props.onPress(!props.val)}
+    disabled={props.disabled}>
     <View style={styles.switch}>
       <Text style={styles.label}>{props.name}</Text>
       <Switch
         trackColor={tintColor}
-        onValueChange={(v) => props.onPress(v)}
+        onValueChange={v => props.onPress(v)}
         value={props.val}
         disabled={props.disabled}
       />
@@ -307,7 +309,7 @@ export default class App extends Component {
       highlightChildren: false,
       selectChildren: false,
       hideChipRemove: false,
-      hasErrored: false,
+      hasErrored: false
     }
     this.termId = 100
     this.maxItems = 5
@@ -330,7 +332,8 @@ export default class App extends Component {
 
     let iconComponent
     // the colour in the url on this site has to be a hex w/o hash
-    const iconColor = color && color.substr(0, 1) === '#' ? `${color.substr(1)}/` : '/'
+    const iconColor =
+      color && color.substr(0, 1) === '#' ? `${color.substr(1)}/` : '/'
 
     const Search = (
       <Image
@@ -359,7 +362,9 @@ export default class App extends Component {
 
     const Check = (
       <Image
-        source={{ uri: `https://png.icons8.com/checkmark/${iconColor}android/` }}
+        source={{
+          uri: `https://png.icons8.com/checkmark/${iconColor}android/`
+        }}
         style={{ width: size / 1.5, height: size / 1.5 }}
       />
     )
@@ -408,13 +413,15 @@ export default class App extends Component {
   }
 
   // testing a custom filtering function that ignores accents
-  removerAcentos = (s) => s.replace(/[\W\[\] ]/g, (a) => accentMap[a] || a)
+  removerAcentos = s => s.replace(/[\W\[\] ]/g, a => accentMap[a] || a)
 
   filterItems = (searchTerm, items, { subKey, displayKey, uniqueKey }) => {
     let filteredItems = []
     let newFilteredItems = []
-    items.forEach((item) => {
-      const parts = this.removerAcentos(searchTerm.trim()).split(/[[ \][)(\\/?\-:]+/)
+    items.forEach(item => {
+      const parts = this.removerAcentos(searchTerm.trim()).split(
+        /[[ \][)(\\/?\-:]+/
+      )
       const regex = new RegExp(`(${parts.join('|')})`, 'i')
       if (regex.test(this.getProp(item, displayKey))) {
         filteredItems.push(item)
@@ -422,12 +429,12 @@ export default class App extends Component {
       if (item[subKey]) {
         const newItem = Object.assign({}, item)
         newItem[subKey] = []
-        item[subKey].forEach((sub) => {
+        item[subKey].forEach(sub => {
           if (regex.test(this.getProp(sub, displayKey))) {
             newItem[subKey] = [...newItem[subKey], sub]
             newFilteredItems = this.rejectProp(
               filteredItems,
-              (singleItem) => item[uniqueKey] !== singleItem[uniqueKey]
+              singleItem => item[uniqueKey] !== singleItem[uniqueKey]
             )
             newFilteredItems.push(newItem)
             filteredItems = newFilteredItems
@@ -438,7 +445,7 @@ export default class App extends Component {
     return filteredItems
   }
 
-  onSelectedItemsChange = (selectedItems) => {
+  onSelectedItemsChange = selectedItems => {
     console.log(selectedItems, selectedItems.length)
 
     if (selectedItems.length >= this.maxItems) {
@@ -446,20 +453,24 @@ export default class App extends Component {
         this.setState({ selectedItems })
       }
       this.setState({
-        maxItems: true,
+        maxItems: true
       })
       return
     }
     this.setState({
-      maxItems: false,
+      maxItems: false
     })
 
-    const filteredItems = selectedItems.filter((val) => !this.state.selectedItems2.includes(val))
+    const filteredItems = selectedItems.filter(
+      val => !this.state.selectedItems2.includes(val)
+    )
     this.setState({ selectedItems: filteredItems })
   }
 
-  onSelectedItemsChange2 = (selectedItems) => {
-    const filteredItems = selectedItems.filter((val) => !this.state.selectedItems.includes(val))
+  onSelectedItemsChange2 = selectedItems => {
+    const filteredItems = selectedItems.filter(
+      val => !this.state.selectedItems.includes(val)
+    )
     this.setState({ selectedItems2: filteredItems })
   }
 
@@ -470,16 +481,16 @@ export default class App extends Component {
     this.SectionedMultiSelect._removeAllItems()
 
     this.setState({
-      selectedItems: this.state.currentItems,
+      selectedItems: this.state.currentItems
     })
     console.log(this.state.selectedItems)
   }
-  onSelectedItemObjectsChange = (selectedItemObjects) => {
+  onSelectedItemObjectsChange = selectedItemObjects => {
     this.setState({ selectedItemObjects })
     console.log(selectedItemObjects)
   }
 
-  onSwitchToggle = (k) => {
+  onSwitchToggle = k => {
     const v = !this.state[k]
     this.setState({ [k]: v })
   }
@@ -487,18 +498,18 @@ export default class App extends Component {
   fetchCategories = () => {
     this.setState({ hasErrored: false })
     fetch('http://www.mocky.io/v2/5a5573a22f00005c04beea49?mocky-delay=500ms', {
-      headers: 'no-cache',
+      headers: 'no-cache'
     })
-      .then((response) => response.json())
-      .then((responseJson) => {
+      .then(response => response.json())
+      .then(responseJson => {
         this.setState({ cats: responseJson })
       })
-      .catch((error) => {
+      .catch(error => {
         this.setState({ hasErrored: true })
         throw error.message
       })
   }
-  filterDuplicates = (items) =>
+  filterDuplicates = items =>
     items.sort().reduce((accumulator, current) => {
       const length = accumulator.length
       if (length === 0 || accumulator[length - 1] !== current) {
@@ -518,23 +529,22 @@ export default class App extends Component {
     const id = (this.termId += 1)
     if (
       searchTerm.length &&
-      !(this.state.items || []).some((item) => item.title.includes(searchTerm))
+      !(this.state.items || []).some(item => item.title.includes(searchTerm))
     ) {
       const newItem = { id, title: searchTerm }
-      this.setState((prevState) => ({
-        items: [...(prevState.items || []), newItem],
+      this.setState(prevState => ({
+        items: [...(prevState.items || []), newItem]
       }))
       this.onSelectedItemsChange([...this.state.selectedItems, id])
       this.SectionedMultiSelect._submitSelection()
     }
   }
 
-  searchAdornment = (searchTerm) =>
+  searchAdornment = searchTerm =>
     searchTerm.length ? (
       <TouchableOpacity
         style={{ alignItems: 'center', justifyContent: 'center' }}
-        onPress={this.handleAddSearchTerm}
-      >
+        onPress={this.handleAddSearchTerm}>
         <View style={{}}>
           <Image
             source={{ uri: 'https://png.icons8.com/plus' }}
@@ -543,20 +553,21 @@ export default class App extends Component {
           {/*   <Icon size={18} style={{ marginHorizontal: 15 }} name="add" /> */}
         </View>
       </TouchableOpacity>
-    ) : null;
+    ) : null
 
   renderSelectText = () => {
     const { selectedItemObjects } = this.state
 
     const selectText = selectedItemObjects.length
       ? `I like ${selectedItemObjects
-        .map((item, i) => {
-          let label = `${item.title}, `
-          if (i === selectedItemObjects.length - 2) label = `${item.title} and `
-          if (i === selectedItemObjects.length - 1) label = `${item.title}.`
-          return label
-        })
-        .join('')}`
+          .map((item, i) => {
+            let label = `${item.title}, `
+            if (i === selectedItemObjects.length - 2)
+              label = `${item.title} and `
+            if (i === selectedItemObjects.length - 1) label = `${item.title}.`
+            return label
+          })
+          .join('')}`
       : 'Select a fruit'
     return <Text style={{ color: 'red', fontSize: 24 }}>{selectText}</Text>
   }
@@ -570,29 +581,28 @@ export default class App extends Component {
           borderWidth: 0,
           paddingHorizontal: 10,
           backgroundColor: 'darkgrey',
-          alignItems: 'center',
+          alignItems: 'center'
         }}
         onPress={
           this.state.selectedItems.length
             ? this.SectionedMultiSelect._removeAllItems
             : this.SectionedMultiSelect._selectAllItems
-        }
-      >
+        }>
         <Text style={{ color: 'white', fontWeight: 'bold' }}>
           {this.state.selectedItems.length ? 'Remove' : 'Select'} all
         </Text>
       </TouchableOpacity>
     )
 
-  onToggleSelector = (toggled) => {
+  onToggleSelector = toggled => {
     console.log('selector is ', toggled ? 'open' : 'closed')
   }
-  customChipsRenderer = (props) => {
+  customChipsRenderer = props => {
     console.log('props', props)
     return (
       <View style={{ backgroundColor: 'yellow', padding: 15 }}>
         <Text>Selected:</Text>
-        {props.selectedItems.map((singleSelectedItem) => {
+        {props.selectedItems.map(singleSelectedItem => {
           const item = this.SectionedMultiSelect._findItem(singleSelectedItem)
 
           if (!item || !item[props.displayKey]) return null
@@ -604,14 +614,12 @@ export default class App extends Component {
                 flex: 0,
                 marginRight: 5,
                 padding: 10,
-                backgroundColor: 'orange',
-              }}
-            >
+                backgroundColor: 'orange'
+              }}>
               <TouchableOpacity
                 onPress={() => {
                   this.SectionedMultiSelect._removeItem(item)
-                }}
-              >
+                }}>
                 <Text>{item[props.displayKey]}</Text>
               </TouchableOpacity>
             </View>
@@ -625,12 +633,15 @@ export default class App extends Component {
       <ScrollView
         keyboardShouldPersistTaps="always"
         style={{ backgroundColor: '#f8f8f8' }}
-        contentContainerStyle={styles.container}
-      >
-        <Text style={styles.welcome}>React native sectioned multi select example.</Text>
+        contentContainerStyle={styles.container}>
+        <Text style={styles.welcome}>
+          React native sectioned multi select example.
+        </Text>
         <SectionedMultiSelect
           items={this.state.items}
-          ref={(SectionedMultiSelect) => (this.SectionedMultiSelect = SectionedMultiSelect)}
+          ref={SectionedMultiSelect =>
+            (this.SectionedMultiSelect = SectionedMultiSelect)
+          }
           uniqueKey="id"
           subKey="children"
           displayKey="title"
@@ -646,13 +657,16 @@ export default class App extends Component {
           // alwaysShowSelectText
           // customChipsRenderer={this.customChipsRenderer}
           chipsPosition="top"
-          searchAdornment={(searchTerm) => this.searchAdornment(searchTerm)}
+          searchAdornment={searchTerm => this.searchAdornment(searchTerm)}
           renderSelectText={this.renderSelectText}
           // noResultsComponent={this.noResults}
           loadingComponent={
-            <Loading hasErrored={this.state.hasErrored} fetchCategories={this.fetchCategories} />
+            <Loading
+              hasErrored={this.state.hasErrored}
+              fetchCategories={this.fetchCategories}
+            />
           }
-          // iconRenderer={this.icon}
+          IconRenderer={Icon}
           //  cancelIconComponent={<Text style={{color:'white'}}>Cancel</Text>}
           showDropDowns={this.state.showDropDowns}
           expandDropDowns={this.state.expandDropDowns}
@@ -671,7 +685,7 @@ export default class App extends Component {
           onConfirm={this.onConfirm}
           confirmText={`${this.state.selectedItems.length}/${this.maxItems} - ${
             this.state.maxItems ? 'Max selected' : 'Confirm'
-            }`}
+          }`}
           selectedItems={this.state.selectedItems}
           colors={{ primary: '#5c3a9e', success: '#5c3a9e' }}
           itemNumberOfLines={3}
@@ -690,23 +704,23 @@ export default class App extends Component {
             //   color: this.state.selectedItems.length ? 'black' : 'lightgrey'
             // },
             item: {
-              paddingHorizontal: 10,
+              paddingHorizontal: 10
             },
             subItem: {
-              paddingHorizontal: 10,
+              paddingHorizontal: 10
             },
             selectedItem: {
-              backgroundColor: 'rgba(0,0,0,0.1)',
+              backgroundColor: 'rgba(0,0,0,0.1)'
             },
             selectedSubItem: {
-              backgroundColor: 'rgba(0,0,0,0.1)',
+              backgroundColor: 'rgba(0,0,0,0.1)'
             },
             // selectedSubItemText: {
             //   color: 'blue',
             // },
-            scrollView: { paddingHorizontal: 0 },
+            scrollView: { paddingHorizontal: 0 }
           }}
-        // cancelIconComponent={<Icon size={20} name="close" style={{ color: 'white' }} />}
+          // cancelIconComponent={<Icon size={20} name="close" style={{ color: 'white' }} />}
         />
         <View>
           <View style={styles.border}>
@@ -752,7 +766,8 @@ export default class App extends Component {
             val={this.state.hideChipRemove}
           />
 
-          <TouchableWithoutFeedback onPress={() => this.SectionedMultiSelect._removeAllItems()}>
+          <TouchableWithoutFeedback
+            onPress={() => this.SectionedMultiSelect._removeAllItems()}>
             <View style={styles.switch}>
               <Text style={styles.label}>Remove All</Text>
             </View>

--- a/exampleapp/__tests__/App.js
+++ b/exampleapp/__tests__/App.js
@@ -1,12 +1,24 @@
-import 'react-native';
-import React from 'react';
-import App from '../App';
-
+import 'react-native'
+import React from 'react'
+import SectionedMultiSelect from 'react-native-sectioned-multi-select'
+import App from '../App'
 // Note: test renderer must be required after react-native.
-import renderer from 'react-test-renderer';
+import renderer from 'react-test-renderer'
 
-it('renders correctly', () => {
-  const tree = renderer.create(
-    <App />
-  );
-});
+// 'it probably didn't break'
+
+const tree = renderer.create(<App />)
+it('renders example app correctly', () => {
+  tree
+})
+it('matches the snapshot', () => {
+  // make assertions on tree
+  expect(tree.toJSON()).toMatchSnapshot()
+})
+
+const testInstance = tree.root
+it('has an expected prop', () => {
+  expect(testInstance.findAllByType(SectionedMultiSelect)[0].props.single).toBe(
+    false
+  )
+})

--- a/exampleapp/__tests__/__snapshots__/App.js.snap
+++ b/exampleapp/__tests__/__snapshots__/App.js.snap
@@ -1,0 +1,680 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches the snapshot 1`] = `
+<RCTScrollView
+  contentContainerStyle={
+    Object {
+      "paddingHorizontal": 20,
+      "paddingTop": 40,
+    }
+  }
+  keyboardShouldPersistTaps="always"
+  style={
+    Object {
+      "backgroundColor": "#f8f8f8",
+    }
+  }
+>
+  <View>
+    <Text
+      style={
+        Object {
+          "color": "#333",
+          "fontSize": 20,
+          "margin": 10,
+          "textAlign": "center",
+        }
+      }
+    >
+      React native sectioned multi select example.
+    </Text>
+    <View>
+      <Modal
+        animationType="fade"
+        hardwareAccelerated={false}
+        onRequestClose={[Function]}
+        supportedOrientations={
+          Array [
+            "portrait",
+            "landscape",
+          ]
+        }
+        transparent={true}
+        visible={false}
+      >
+        <RCTSafeAreaView
+          emulateUnlessSupported={true}
+          style={
+            Array [
+              Object {
+                "backgroundColor": "rgba(0,0,0,0.5)",
+                "flex": 1,
+              },
+              Object {},
+            ]
+          }
+        >
+          <View
+            accessible={true}
+            focusable={true}
+            onClick={[Function]}
+            onResponderGrant={[Function]}
+            onResponderMove={[Function]}
+            onResponderRelease={[Function]}
+            onResponderTerminate={[Function]}
+            onResponderTerminationRequest={[Function]}
+            onStartShouldSetResponder={[Function]}
+            style={
+              Array [
+                Object {
+                  "bottom": 0,
+                  "flex": 1,
+                  "left": 0,
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "zIndex": 0,
+                },
+                undefined,
+              ]
+            }
+          />
+          <View
+            style={
+              Array [
+                Object {
+                  "alignSelf": "stretch",
+                  "backgroundColor": "white",
+                  "borderRadius": 6,
+                  "flex": 1,
+                  "marginHorizontal": 18,
+                  "marginVertical": 26,
+                  "overflow": "hidden",
+                },
+                Object {},
+              ]
+            }
+          >
+            <View
+              style={
+                Array [
+                  Object {
+                    "flexDirection": "row",
+                    "paddingVertical": 5,
+                  },
+                  Object {
+                    "backgroundColor": "#f8f8f8",
+                    "flexDirection": "row",
+                  },
+                ]
+              }
+            >
+              <View
+                style={
+                  Object {
+                    "alignItems": "center",
+                    "justifyContent": "center",
+                  }
+                }
+              >
+                <Text
+                  allowFontScaling={false}
+                  style={
+                    Array [
+                      Object {
+                        "color": undefined,
+                        "fontSize": 18,
+                      },
+                      Object {
+                        "marginHorizontal": 15,
+                      },
+                      Object {
+                        "fontFamily": "Material Icons",
+                        "fontStyle": "normal",
+                        "fontWeight": "normal",
+                      },
+                    ]
+                  }
+                >
+                  
+                </Text>
+              </View>
+              <TextInput
+                allowFontScaling={true}
+                autoFocus={true}
+                onChangeText={[Function]}
+                placeholder="Search categories..."
+                placeholderTextColor="#999"
+                rejectResponderTermination={true}
+                selectTextOnFocus={true}
+                selectionColor="rgba(0,0,0,0.2)"
+                style={
+                  Array [
+                    Object {
+                      "flex": 1,
+                      "fontSize": 17,
+                      "paddingVertical": 8,
+                    },
+                    Object {
+                      "fontFamily": "Avenir",
+                      "fontWeight": "200",
+                    },
+                    Object {},
+                  ]
+                }
+                underlineColorAndroid="transparent"
+                value=""
+              />
+            </View>
+            <View
+              keyboardShouldPersistTaps="always"
+              style={
+                Array [
+                  Object {
+                    "flex": 1,
+                    "paddingHorizontal": 12,
+                  },
+                  Object {
+                    "paddingHorizontal": 0,
+                  },
+                ]
+              }
+            >
+              <View>
+                <View
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "flex": 1,
+                      "justifyContent": "center",
+                      "marginTop": 30,
+                    }
+                  }
+                >
+                  <ActivityIndicator
+                    animating={true}
+                    color="#999999"
+                    hidesWhenStopped={true}
+                    size="large"
+                  />
+                </View>
+              </View>
+            </View>
+            <View
+              style={
+                Object {
+                  "flexDirection": "row",
+                }
+              }
+            >
+              <View
+                accessible={true}
+                focusable={true}
+                isTVSelectable={true}
+                onClick={[Function]}
+                onResponderGrant={[Function]}
+                onResponderMove={[Function]}
+                onResponderRelease={[Function]}
+                onResponderTerminate={[Function]}
+                onResponderTerminationRequest={[Function]}
+                onStartShouldSetResponder={[Function]}
+                style={
+                  Object {
+                    "flex": 1,
+                    "opacity": 1,
+                  }
+                }
+              >
+                <View
+                  style={
+                    Array [
+                      Object {
+                        "alignItems": "center",
+                        "backgroundColor": "#5c3a9e",
+                        "borderRadius": 0,
+                        "flex": 0,
+                        "flexDirection": "row",
+                        "justifyContent": "center",
+                        "paddingHorizontal": 16,
+                        "paddingVertical": 8,
+                      },
+                      Object {},
+                    ]
+                  }
+                >
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "color": "#ffffff",
+                          "fontSize": 18,
+                        },
+                        Object {
+                          "fontFamily": "Avenir",
+                          "fontWeight": "bold",
+                        },
+                        Object {},
+                      ]
+                    }
+                  >
+                    0/5 - Confirm
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </RCTSafeAreaView>
+      </Modal>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "flexDirection": "row",
+              "flexWrap": "wrap",
+            },
+            Object {
+              "borderRadius": 4,
+              "marginBottom": 15,
+              "marginTop": 5,
+              "paddingHorizontal": 10,
+              "paddingVertical": 12,
+            },
+          ]
+        }
+      >
+        <Text
+          style={
+            Object {
+              "color": "red",
+              "fontSize": 24,
+            }
+          }
+        >
+          Select a fruit
+        </Text>
+        <Text
+          allowFontScaling={false}
+          style={
+            Array [
+              Object {
+                "color": undefined,
+                "fontSize": 24,
+              },
+              Object {
+                "color": "#333",
+              },
+              Object {
+                "fontFamily": "Material Icons",
+                "fontStyle": "normal",
+                "fontWeight": "normal",
+              },
+            ]
+          }
+        >
+          
+        </Text>
+      </View>
+    </View>
+    <View>
+      <View
+        style={
+          Object {
+            "borderBottomColor": "#dadada",
+            "borderBottomWidth": 1,
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontSize": 24,
+              "fontWeight": "bold",
+              "marginBottom": 5,
+              "marginTop": 20,
+            }
+          }
+        >
+          Settings
+        </Text>
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Single
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Read only headings
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Expand dropdowns
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          disabled={true}
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Show dropdown toggles
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Auto-highlight children
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          disabled={false}
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Auto-select children
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          disabled={false}
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Hide Chip Remove Buttons
+        </Text>
+        <RCTSwitch
+          accessibilityRole="button"
+          onChange={[Function]}
+          onResponderTerminationRequest={[Function]}
+          onStartShouldSetResponder={[Function]}
+          style={
+            Object {
+              "height": 31,
+              "width": 51,
+            }
+          }
+          value={false}
+        />
+      </View>
+      <View
+        accessible={true}
+        focusable={true}
+        onClick={[Function]}
+        onResponderGrant={[Function]}
+        onResponderMove={[Function]}
+        onResponderRelease={[Function]}
+        onResponderTerminate={[Function]}
+        onResponderTerminationRequest={[Function]}
+        onStartShouldSetResponder={[Function]}
+        style={
+          Object {
+            "alignItems": "flex-end",
+            "flexDirection": "row",
+            "justifyContent": "space-between",
+            "marginBottom": 20,
+          }
+        }
+      >
+        <Text
+          style={
+            Object {
+              "fontWeight": "bold",
+            }
+          }
+        >
+          Remove All
+        </Text>
+      </View>
+    </View>
+  </View>
+</RCTScrollView>
+`;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,121 +1,150 @@
-import * as React from 'react';
-import * as ReactNative from 'react-native';
+import * as React from 'react'
+import * as ReactNative from 'react-native'
 
 export interface Styles {
-  container?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  modalWrapper?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  selectToggle?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  selectToggleText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  item?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  subItem?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  itemText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  selectedItemText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  selectedSubItemText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  subItemText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  searchBar?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  center?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  separator?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  subSeparator?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  chipsWrapper?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  chipContainer?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  chipText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  chipIcon?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  searchTextInput?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  scrollView?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  button?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  cancelButton?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  confirmText?: ReactNative.StyleProp<ReactNative.TextStyle>;
-  toggleIcon?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  selectedItem?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  selectedSubItem?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  backdrop?: ReactNative.StyleProp<ReactNative.ViewStyle>;
-  listContainer?: ReactNative.StyleProp<ReactNative.ViewStyle>;
+  container?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  modalWrapper?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  selectToggle?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  selectToggleText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  item?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  subItem?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  itemText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  selectedItemText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  selectedSubItemText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  subItemText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  searchBar?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  center?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  separator?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  subSeparator?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  chipsWrapper?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  chipContainer?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  chipText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  chipIcon?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  searchTextInput?: ReactNative.StyleProp<ReactNative.TextStyle>
+  scrollView?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  button?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  cancelButton?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  confirmText?: ReactNative.StyleProp<ReactNative.TextStyle>
+  toggleIcon?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  selectedItem?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  selectedSubItem?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  backdrop?: ReactNative.StyleProp<ReactNative.ViewStyle>
+  listContainer?: ReactNative.StyleProp<ReactNative.ViewStyle>
 }
 
 export interface SectionedMultiSelectProps<ItemType> {
-  single?: boolean;
-  selectedItems?: any[];
-  items?: ItemType[];
-  displayKey?: string;
-  uniqueKey: string;
-  subKey?: string;
-  onSelectedItemsChange: (items: ItemType[]) => void;
-  showDropDowns?: boolean;
-  showChips?: boolean;
-  readOnlyHeadings?: boolean;
-  selectText?: string;
-  selectedText?: string | (() => void);
-  renderSelectText?: (props: object) => void;
-  confirmText?: string;
-  hideConfirm?: boolean;
-  styles?: Styles;
+  single?: boolean
+  selectedItems?: any[]
+  items?: ItemType[]
+  displayKey?: string
+  uniqueKey: string
+  subKey?: string
+  onSelectedItemsChange: (items: ItemType[]) => void
+  showDropDowns?: boolean
+  showChips?: boolean
+  readOnlyHeadings?: boolean
+  selectText?: string
+  selectedText?: string | (() => void)
+  renderSelectText?: (props: object) => void
+  confirmText?: string
+  hideConfirm?: boolean
+  styles?: Styles
   colors?: {
-    primary?: string;
-    success?: string;
-    cancel?: string;
-    text?: string;
-    subText?: string;
-    selectToggleTextColor?: string;
-    searchPlaceholderTextColor?: string;
-    searchSelectionColor?: string;
-    chipColor?: string;
-    itemBackground?: string;
-    subItemBackground?: string;
-    disabled?: string;
-  };
-  searchPlaceholderText?: string;
-  noResultsComponent?: (() => void) | JSX.Element;
-  loadingComponent?: (() => void) | JSX.Element;
-  loading?: boolean;
-  subItemFontFamily?: object;
-  itemFontFamily?: object;
-  searchTextFontFamily?: object;
-  confirmFontFamily?: object;
-  showRemoveAll?: boolean;
-  removeAllText?: string;
-  modalSupportedOrientations?: ReactNative.ModalProps['supportedOrientations'];
-  modalAnimationType?: string;
-  modalWithSafeAreaView?: boolean;
-  modalWithTouchable?: boolean;
-  hideSearch?: boolean;
-  footerComponent?: (() => void) | JSX.Element;
-  stickyFooterComponent?: (() => void) | JSX.Element;
-  selectToggleIconComponent?: (() => void) | JSX.Element;
-  cancelIconComponent?: (() => void) | JSX.Element;
-  searchIconComponent?: (() => void) | JSX.Element;
-  selectedIconComponent?: (() => void) | JSX.Element;
-  unselectedIconComponent?: (() => void) | JSX.Element;
-  dropDownToggleIconUpComponent?: (() => void) | JSX.Element;
-  dropDownToggleIconDownComponent?: (() => void) | JSX.Element;
-  chipRemoveIconComponent?: (() => void) | JSX.Element;
-  selectChildren?: boolean;
-  highlightChildren?: boolean;
-  onSelectedItemObjectsChange?: (items: ItemType[]) => void;
-  itemNumberOfLines?: number;
-  selectLabelNumberOfLines?: number;
-  showCancelButton?: boolean;
-  hideSelect?: boolean;
-  onConfirm?: () => void;
-  onCancel?: () => void;
-  headerComponent?: (() => void) | JSX.Element;
-  alwaysShowSelectText?: boolean;
-  searchAdornment?: (searchText: string) => void;
-  expandDropDowns?: boolean;
-  animateDropDowns?: boolean;
-  customLayoutAnimation?: object;
-  filterItems?: (searchTerm: string) => void;
-  onToggleSelector?: (selected: boolean) => void;
-  noItemsComponent?: (() => void) | JSX.Element;
-  customChipsRenderer?: (chipProperties: object) => void;
-  chipsPosition?: 'top' | 'bottom';
-  autoFocus?: boolean;
-  iconKey?: string;
-  disabled?: boolean;
-  selectedIconOnLeft?: boolean;
-  parentChipsRemoveChildren?: boolean;
-  iconRenderer?: (() => void) | JSX.Element;
-  itemsFlatListProps?: Omit<ReactNative.FlatListProps<T>, 'data' | 'renderItem'>;
-  subItemsFlatListProps?: Omit<ReactNative.FlatListProps<T>, 'data' | 'renderItem'>;
+    primary?: string
+    success?: string
+    cancel?: string
+    text?: string
+    subText?: string
+    selectToggleTextColor?: string
+    searchPlaceholderTextColor?: string
+    searchSelectionColor?: string
+    chipColor?: string
+    itemBackground?: string
+    subItemBackground?: string
+    disabled?: string
+  }
+  searchPlaceholderText?: string
+  noResultsComponent?: (() => void) | JSX.Element
+  loadingComponent?: (() => void) | JSX.Element
+  loading?: boolean
+  subItemFontFamily?: object
+  itemFontFamily?: object
+  searchTextFontFamily?: object
+  confirmFontFamily?: object
+  showRemoveAll?: boolean
+  removeAllText?: string
+  modalSupportedOrientations?: ReactNative.ModalProps['supportedOrientations']
+  modalAnimationType?: string
+  modalWithSafeAreaView?: boolean
+  modalWithTouchable?: boolean
+  hideSearch?: boolean
+  footerComponent?: (() => void) | JSX.Element
+  stickyFooterComponent?: (() => void) | JSX.Element
+  selectToggleIconComponent?: (() => void) | JSX.Element
+  cancelIconComponent?: (() => void) | JSX.Element
+  searchIconComponent?: (() => void) | JSX.Element
+  selectedIconComponent?: (() => void) | JSX.Element
+  unselectedIconComponent?: (() => void) | JSX.Element
+  dropDownToggleIconUpComponent?: (() => void) | JSX.Element
+  dropDownToggleIconDownComponent?: (() => void) | JSX.Element
+  chipRemoveIconComponent?: (() => void) | JSX.Element
+  selectChildren?: boolean
+  highlightChildren?: boolean
+  onSelectedItemObjectsChange?: (items: ItemType[]) => void
+  itemNumberOfLines?: number
+  selectLabelNumberOfLines?: number
+  showCancelButton?: boolean
+  hideSelect?: boolean
+  onConfirm?: () => void
+  onCancel?: () => void
+  headerComponent?: (() => void) | JSX.Element
+  alwaysShowSelectText?: boolean
+  searchAdornment?: (searchText: string) => void
+  expandDropDowns?: boolean
+  animateDropDowns?: boolean
+  customLayoutAnimation?: object
+  filterItems?: (searchTerm: string) => void
+  onToggleSelector?: (selected: boolean) => void
+  noItemsComponent?: (() => void) | JSX.Element
+  customChipsRenderer?: (chipProperties: object) => void
+  chipsPosition?: 'top' | 'bottom'
+  autoFocus?: boolean
+  iconKey?: string
+  disabled?: boolean
+  selectedIconOnLeft?: boolean
+  parentChipsRemoveChildren?: boolean
+  IconRenderer?: (() => void) | JSX.Element
+  itemsFlatListProps?: Omit<ReactNative.FlatListProps<T>, 'data' | 'renderItem'>
+  subItemsFlatListProps?: Omit<
+    ReactNative.FlatListProps<T>,
+    'data' | 'renderItem'
+  >
+  icons: {
+    search: {
+      name: string
+      size: number
+    }
+    arrowUp: {
+      name: string
+      size: number
+    }
+    arrowDown: {
+      name: string
+      size: number
+    }
+    close: {
+      name: string
+      size: number
+    }
+    check: {
+      name: string
+      size: number
+    }
+    cancel: {
+      name: string
+      size: number
+    }
+  }
 }
 export default class SectionedMultiSelect<ItemType> extends React.Component<
   SectionedMultiSelectProps<ItemType>

--- a/lib/components/ItemIcon.js
+++ b/lib/components/ItemIcon.js
@@ -1,25 +1,22 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { Image } from 'react-native'
-// import Icon from 'react-native-vector-icons/MaterialIcons'
 
 const ItemIcon = ({ iconRenderer: Icon, icon, iconKey, itemIconStyle }) => {
-  return (
-    typeof icon === 'object' || typeof icon === 'number' ?
-      <Image
-        source={icon}
-        style={[{
+  return typeof icon === 'object' || typeof icon === 'number' ? (
+    <Image
+      source={icon}
+      style={[
+        {
           width: 16,
           height: 16,
-          marginHorizontal: 10,
-        }, itemIconStyle]
-        }
-      />
-      :
-      <Icon
-        name={icon}
-        style={[{ fontSize: 16 }, itemIconStyle]}
-      />
+          marginHorizontal: 10
+        },
+        itemIconStyle
+      ]}
+    />
+  ) : (
+    <Icon name={icon} style={[{ fontSize: 16 }, itemIconStyle]} />
   )
 }
 ItemIcon.propTypes = {
@@ -28,9 +25,9 @@ ItemIcon.propTypes = {
   icon: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.shape({
-      uri: PropTypes.string,
+      uri: PropTypes.string
     }),
-    PropTypes.number,
-  ]).isRequired,
+    PropTypes.number
+  ]).isRequired
 }
 export default ItemIcon

--- a/lib/components/RowItem.js
+++ b/lib/components/RowItem.js
@@ -190,12 +190,11 @@ class RowItem extends Component {
     return this._itemSelected(item)
       ? callIfFunction(selectedIconComponent) || (
           <Icon
-            name={icons.check.name}
-            size={icons.check.size}
             style={{
               color: mergedColors.success,
               paddingLeft: 10
             }}
+            {...icons.check}
           />
         )
       : callIfFunction(unselectedIconComponent) || null
@@ -289,11 +288,10 @@ class RowItem extends Component {
                 <View>
                   {callIfFunction(dropDownToggleIconUpComponent) || (
                     <Icon
-                      name={icons.arrowUp.name}
-                      size={icons.arrowUp.size}
                       style={{
                         color: mergedColors.primary
                       }}
+                      {...icons.arrowUp}
                     />
                   )}
                 </View>
@@ -301,11 +299,10 @@ class RowItem extends Component {
                 <View>
                   {callIfFunction(dropDownToggleIconDownComponent) || (
                     <Icon
-                      name={icons.arrowDown.name}
-                      size={icons.arrowDown.size}
                       style={{
                         color: mergedColors.primary
                       }}
+                      {...icons.arrowDown}
                     />
                   )}
                 </View>

--- a/lib/components/RowItem.js
+++ b/lib/components/RowItem.js
@@ -8,9 +8,8 @@ import {
   UIManager,
   LayoutAnimation,
   FlatList,
-  StyleSheet,
+  StyleSheet
 } from 'react-native'
-import Icon from 'react-native-vector-icons/MaterialIcons'
 import RowSubItem from './RowSubItem'
 import ItemIcon from './ItemIcon'
 import { callIfFunction } from '../helpers'
@@ -24,7 +23,7 @@ class RowItem extends Component {
     }
     this.state = {
       showSubCategories: false,
-      subToggled: null,
+      subToggled: null
     }
   }
 
@@ -35,13 +34,17 @@ class RowItem extends Component {
   shouldComponentUpdate(nextProps, nextState) {
     if (nextProps.selectedItems !== this.props.selectedItems) {
       if (
-        this.props.selectedItems.includes(this.props.item[this.props.uniqueKey]) &&
+        this.props.selectedItems.includes(
+          this.props.item[this.props.uniqueKey]
+        ) &&
         !nextProps.selectedItems.includes(this.props.item[this.props.uniqueKey])
       ) {
         return true
       }
       if (
-        !this.props.selectedItems.includes(this.props.item[this.props.uniqueKey]) &&
+        !this.props.selectedItems.includes(
+          this.props.item[this.props.uniqueKey]
+        ) &&
         nextProps.selectedItems.includes(this.props.item[this.props.uniqueKey])
       ) {
         return true
@@ -57,15 +60,17 @@ class RowItem extends Component {
 
       if (
         this.props.item[this.props.subKey] &&
-        this.props.item[this.props.subKey].findIndex(el =>
-          nextProps.selectedItems.includes(el[this.props.uniqueKey])) !== -1
+        this.props.item[this.props.subKey].findIndex((el) =>
+          nextProps.selectedItems.includes(el[this.props.uniqueKey])
+        ) !== -1
       ) {
         return true
       }
       if (
         this.props.item[this.props.subKey] &&
-        this.props.item[this.props.subKey].findIndex(el =>
-          this.props.selectedItems.includes(el[this.props.uniqueKey])) !== -1
+        this.props.item[this.props.subKey].findIndex((el) =>
+          this.props.selectedItems.includes(el[this.props.uniqueKey])
+        ) !== -1
       ) {
         return true
       }
@@ -114,7 +119,8 @@ class RowItem extends Component {
 
   _toggleDropDown = () => {
     const { customLayoutAnimation, animateDropDowns } = this.props
-    const animation = customLayoutAnimation || LayoutAnimation.Presets.easeInEaseOut
+    const animation =
+      customLayoutAnimation || LayoutAnimation.Presets.easeInEaseOut
     animateDropDowns && LayoutAnimation.configureNext(animation)
     this.setState({ showSubCategories: !this.state.showSubCategories })
   }
@@ -133,7 +139,11 @@ class RowItem extends Component {
 
   _dropDownOrToggle = () => {
     const {
-      readOnlyHeadings, showDropDowns, uniqueKey, subKey, item,
+      readOnlyHeadings,
+      showDropDowns,
+      uniqueKey,
+      subKey,
+      item
     } = this.props
 
     const hasChildren = !!(item[subKey] && item[subKey].length)
@@ -162,37 +172,39 @@ class RowItem extends Component {
           flex: 1,
           height: StyleSheet.hairlineWidth,
           alignSelf: 'stretch',
-          backgroundColor: '#dadada',
+          backgroundColor: '#dadada'
         },
-        this.props.mergedStyles.subSeparator,
+        this.props.mergedStyles.subSeparator
       ]}
     />
   )
   _renderSelectedIcon = () => {
     const {
       item,
+      icons,
       selectedIconComponent,
       mergedColors,
       unselectedIconComponent,
-      iconRenderer: Icon,
+      iconRenderer: Icon
     } = this.props
     return this._itemSelected(item)
       ? callIfFunction(selectedIconComponent) || (
-      <Icon
-        name="check"
-        style={{
-              fontSize: 16,
+          <Icon
+            name={icons.check.name}
+            size={icons.check.size}
+            style={{
               color: mergedColors.success,
-              paddingLeft: 10,
+              paddingLeft: 10
             }}
-      />
-      )
+          />
+        )
       : callIfFunction(unselectedIconComponent) || null
   }
 
   render() {
     const {
       item,
+      icons,
       mergedStyles,
       mergedColors,
       uniqueKey,
@@ -208,7 +220,7 @@ class RowItem extends Component {
       selectedItems,
       iconKey,
       iconRenderer: Icon,
-      subItemsFlatListProps,
+      subItemsFlatListProps
     } = this.props
     const hasDropDown = item[subKey] && item[subKey].length > 0 && showDropDowns
 
@@ -219,9 +231,8 @@ class RowItem extends Component {
           style={{
             flexDirection: 'row',
             flex: 1,
-            backgroundColor: mergedColors.itemBackground,
-          }}
-        >
+            backgroundColor: mergedColors.itemBackground
+          }}>
           <TouchableOpacity
             disabled={(readOnlyHeadings && !showDropDowns) || item.disabled}
             onPress={this._dropDownOrToggle}
@@ -231,12 +242,11 @@ class RowItem extends Component {
                 flexDirection: 'row',
                 alignItems: 'center',
                 justifyContent: 'flex-start',
-                paddingVertical: 6,
+                paddingVertical: 6
               },
               mergedStyles.item,
-              this._itemSelected(item) && mergedStyles.selectedItem,
-            ]}
-          >
+              this._itemSelected(item) && mergedStyles.selectedItem
+            ]}>
             {selectedIconOnLeft && this._renderSelectedIcon()}
             {iconKey && item[iconKey] && (
               <ItemIcon
@@ -251,13 +261,14 @@ class RowItem extends Component {
               style={[
                 {
                   flex: 1,
-                  color: item.disabled ? mergedColors.disabled : mergedColors.text,
+                  color: item.disabled
+                    ? mergedColors.disabled
+                    : mergedColors.text
                 },
                 itemFontFamily,
                 mergedStyles.itemText,
-                this._itemSelected(item) && mergedStyles.selectedItemText,
-              ]}
-            >
+                this._itemSelected(item) && mergedStyles.selectedItemText
+              ]}>
               {item[displayKey]}
             </Text>
             {!selectedIconOnLeft && this._renderSelectedIcon()}
@@ -269,20 +280,19 @@ class RowItem extends Component {
                   alignItems: 'flex-end',
                   justifyContent: 'center',
                   paddingHorizontal: 10,
-                  backgroundColor: 'transparent',
+                  backgroundColor: 'transparent'
                 },
-                mergedStyles.toggleIcon,
+                mergedStyles.toggleIcon
               ]}
-              onPress={this._toggleDropDown}
-            >
+              onPress={this._toggleDropDown}>
               {this._showSubCategoryDropDown() ? (
                 <View>
                   {callIfFunction(dropDownToggleIconUpComponent) || (
                     <Icon
-                      name="keyboard-arrow-up"
-                      size={22}
+                      name={icons.arrowUp.name}
+                      size={icons.arrowUp.size}
                       style={{
-                        color: mergedColors.primary,
+                        color: mergedColors.primary
                       }}
                     />
                   )}
@@ -291,10 +301,10 @@ class RowItem extends Component {
                 <View>
                   {callIfFunction(dropDownToggleIconDownComponent) || (
                     <Icon
-                      name="keyboard-arrow-down"
-                      size={22}
+                      name={icons.arrowDown.name}
+                      size={icons.arrowDown.size}
                       style={{
-                        color: mergedColors.primary,
+                        color: mergedColors.primary
                       }}
                     />
                   )}
@@ -305,7 +315,7 @@ class RowItem extends Component {
         </View>
         {item[subKey] && this._showSubCategoryDropDown() && (
           <FlatList
-            keyExtractor={i => `${i[uniqueKey]}`}
+            keyExtractor={(i) => `${i[uniqueKey]}`}
             data={item[subKey]}
             extraData={selectedItems}
             ItemSeparatorComponent={this._renderSubSeparator}

--- a/lib/components/RowSubItem.js
+++ b/lib/components/RowSubItem.js
@@ -81,14 +81,13 @@ class RowSubItem extends Component {
           callIfFunction(selectedIconComponent)
         ) : (
           <Icon
-            name={icons.check.name}
-            size={icons.check.size}
             style={{
               color: highlightChild
                 ? mergedColors.disabled
                 : mergedColors.success,
               paddingLeft: 10
             }}
+            {...icons.check}
           />
         )}
       </View>

--- a/lib/components/RowSubItem.js
+++ b/lib/components/RowSubItem.js
@@ -8,22 +8,38 @@ class RowSubItem extends Component {
   shouldComponentUpdate(nextProps) {
     if (nextProps.selectedItems !== this.props.selectedItems) {
       if (
-        this.props.selectedItems.includes(this.props.subItem[this.props.uniqueKey]) &&
-        !nextProps.selectedItems.includes(this.props.subItem[this.props.uniqueKey])
+        this.props.selectedItems.includes(
+          this.props.subItem[this.props.uniqueKey]
+        ) &&
+        !nextProps.selectedItems.includes(
+          this.props.subItem[this.props.uniqueKey]
+        )
       ) {
         return true
       }
       if (
-        !this.props.selectedItems.includes(this.props.subItem[this.props.uniqueKey]) &&
-        nextProps.selectedItems.includes(this.props.subItem[this.props.uniqueKey])
+        !this.props.selectedItems.includes(
+          this.props.subItem[this.props.uniqueKey]
+        ) &&
+        nextProps.selectedItems.includes(
+          this.props.subItem[this.props.uniqueKey]
+        )
       ) {
         return true
       }
       if (this.props.highlightChildren || this.props.selectChildren) {
-        if (this.props.highlightedChildren.includes(this.props.subItem[this.props.uniqueKey])) {
+        if (
+          this.props.highlightedChildren.includes(
+            this.props.subItem[this.props.uniqueKey]
+          )
+        ) {
           return true
         }
-        if (nextProps.highlightedChildren.includes(this.props.subItem[this.props.uniqueKey])) {
+        if (
+          nextProps.highlightedChildren.includes(
+            this.props.subItem[this.props.uniqueKey]
+          )
+        ) {
           return true
         }
       }
@@ -53,9 +69,11 @@ class RowSubItem extends Component {
       highlightedChildren,
       uniqueKey,
       subItem,
-      iconRenderer: Icon,
+      icons,
+      iconRenderer: Icon
     } = this.props
-    const highlightChild = !selectChildren && highlightedChildren.includes(subItem[uniqueKey])
+    const highlightChild =
+      !selectChildren && highlightedChildren.includes(subItem[uniqueKey])
     const itemSelected = this._itemSelected()
     return itemSelected || highlightChild ? (
       <View>
@@ -63,11 +81,13 @@ class RowSubItem extends Component {
           callIfFunction(selectedIconComponent)
         ) : (
           <Icon
-            name="check"
+            name={icons.check.name}
+            size={icons.check.size}
             style={{
-              fontSize: 16,
-              color: highlightChild ? mergedColors.disabled : mergedColors.success,
-              paddingLeft: 10,
+              color: highlightChild
+                ? mergedColors.disabled
+                : mergedColors.success,
+              paddingLeft: 10
             }}
           />
         )}
@@ -90,10 +110,11 @@ class RowSubItem extends Component {
       itemNumberOfLines,
       displayKey,
       iconKey,
-        iconRenderer: Icon,
+      iconRenderer: Icon
     } = this.props
 
-    const highlightChild = !selectChildren && highlightedChildren.includes(subItem[uniqueKey])
+    const highlightChild =
+      !selectChildren && highlightedChildren.includes(subItem[uniqueKey])
     const itemSelected = this._itemSelected()
 
     return (
@@ -102,9 +123,8 @@ class RowSubItem extends Component {
         style={{
           flexDirection: 'row',
           flex: 1,
-          backgroundColor: mergedColors.subItemBackground,
-        }}
-      >
+          backgroundColor: mergedColors.subItemBackground
+        }}>
         <TouchableOpacity
           disabled={highlightChild || subItem.disabled}
           onPress={this._toggleItem}
@@ -114,35 +134,36 @@ class RowSubItem extends Component {
               flexDirection: 'row',
               alignItems: 'center',
               justifyContent: 'flex-start',
-              paddingVertical: 6,
+              paddingVertical: 6
             },
             mergedStyles.subItem,
             (itemSelected || highlightChild) && mergedStyles.selectedItem,
-            (itemSelected || highlightChild) && mergedStyles.selectedSubItem,
-          ]}
-        >
+            (itemSelected || highlightChild) && mergedStyles.selectedSubItem
+          ]}>
           {selectedIconOnLeft && this._renderSelectedIcon()}
 
           {iconKey && subItem[iconKey] && (
-              <ItemIcon
-                  iconRenderer={Icon}
-                  iconKey={iconKey}
-                  icon={subItem[iconKey]}
-                  style={mergedStyles.itemIconStyle}
-              />
+            <ItemIcon
+              iconRenderer={Icon}
+              iconKey={iconKey}
+              icon={subItem[iconKey]}
+              style={mergedStyles.itemIconStyle}
+            />
           )}
           <Text
             numberOfLines={itemNumberOfLines}
             style={[
               {
                 flex: 1,
-                color: subItem.disabled ? mergedColors.disabled : mergedColors.subText,
+                color: subItem.disabled
+                  ? mergedColors.disabled
+                  : mergedColors.subText
               },
               subItemFontFamily,
               mergedStyles.subItemText,
-              (itemSelected || highlightChild) && mergedStyles.selectedSubItemText,
-            ]}
-          >
+              (itemSelected || highlightChild) &&
+                mergedStyles.selectedSubItemText
+            ]}>
             {subItem[displayKey]}
           </Text>
           {!selectedIconOnLeft && this._renderSelectedIcon()}

--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -12,13 +12,14 @@ import {
   Modal,
   FlatList,
   StyleSheet,
-  ActivityIndicator,
+  ActivityIndicator
 } from 'react-native'
 import { isEqual } from 'lodash'
 import { RowItem } from './components'
 import { callIfFunction } from './helpers'
 
-const Touchable = Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity
+const Touchable =
+  Platform.OS === 'android' ? TouchableNativeFeedback : TouchableOpacity
 
 const defaultStyles = {
   container: {},
@@ -28,31 +29,31 @@ const defaultStyles = {
     marginBottom: 15,
     paddingHorizontal: 10,
     paddingVertical: 12,
-    borderRadius: 4,
+    borderRadius: 4
   },
   selectToggleText: {},
   item: {},
   subItem: {},
   itemText: {
-    fontSize: 17,
+    fontSize: 17
   },
   selectedItemText: {},
   selectedSubItemText: {},
   subItemText: {
     fontSize: 15,
-    paddingLeft: 8,
+    paddingLeft: 8
   },
   searchBar: {
     backgroundColor: '#f8f8f8',
-    flexDirection: 'row',
+    flexDirection: 'row'
   },
   center: {
     alignItems: 'center',
-    justifyContent: 'center',
+    justifyContent: 'center'
   },
   separator: {},
   subSeparator: {
-    height: 0,
+    height: 0
   },
   chipsWrapper: {},
   chipContainer: {},
@@ -65,7 +66,7 @@ const defaultStyles = {
   confirmText: {},
   toggleIcon: {},
   selectedItem: {},
-  selectedSubItem: {},
+  selectedSubItem: {}
 }
 
 const defaultColors = {
@@ -80,11 +81,14 @@ const defaultColors = {
   chipColor: '#848787',
   itemBackground: '#fff',
   subItemBackground: '#ffffff',
-  disabled: '#d7d7d7',
+  disabled: '#d7d7d7'
 }
 
 const ComponentContainer = ({ children }) => (
-  <View style={{ marginTop: 20, alignItems: 'center', justifyContent: 'center' }}>{children}</View>
+  <View
+    style={{ marginTop: 20, alignItems: 'center', justifyContent: 'center' }}>
+    {children}
+  </View>
 )
 
 const noResults = (
@@ -141,15 +145,42 @@ class SectionedMultiSelect extends PureComponent {
     modalWithTouchable: PropTypes.bool,
     hideSearch: PropTypes.bool,
     footerComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    stickyFooterComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    selectToggleIconComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    cancelIconComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    searchIconComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    selectedIconComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    unselectedIconComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    dropDownToggleIconUpComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    dropDownToggleIconDownComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
-    chipRemoveIconComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    stickyFooterComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    selectToggleIconComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    cancelIconComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    searchIconComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    selectedIconComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    unselectedIconComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    dropDownToggleIconUpComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    dropDownToggleIconDownComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
+    chipRemoveIconComponent: PropTypes.oneOfType([
+      PropTypes.func,
+      PropTypes.object
+    ]),
     selectChildren: PropTypes.bool,
     highlightChildren: PropTypes.bool,
     onSelectedItemObjectsChange: PropTypes.func,
@@ -176,9 +207,10 @@ class SectionedMultiSelect extends PureComponent {
     disabled: PropTypes.bool,
     selectedIconOnLeft: PropTypes.bool,
     parentChipsRemoveChildren: PropTypes.bool,
-    iconRenderer: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    IconRenderer: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
     itemsFlatListProps: PropTypes.object,
     subItemsFlatListProps: PropTypes.object,
+    icons: PropTypes.object
   }
 
   static defaultProps = {
@@ -198,21 +230,47 @@ class SectionedMultiSelect extends PureComponent {
     loading: false,
     styles: {},
     colors: {},
+    icons: {
+      search: {
+        name: 'search',
+        size: 24
+      },
+      arrowUp: {
+        name: 'keyboard-arrow-up',
+        size: 16
+      },
+      arrowDown: {
+        name: 'keyboard-arrow-down',
+        size: 16
+      },
+      close: {
+        name: 'close',
+        size: 22
+      },
+      check: {
+        name: 'check',
+        size: 16
+      },
+      cancel: {
+        name: 'cancel',
+        size: 16
+      }
+    },
     itemFontFamily: {
       fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir',
-      fontWeight: 'bold',
+      fontWeight: 'bold'
     },
     subItemFontFamily: {
       fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir',
-      fontWeight: '200',
+      fontWeight: '200'
     },
     searchTextFontFamily: {
       fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir',
-      fontWeight: '200',
+      fontWeight: '200'
     },
     confirmFontFamily: {
       fontFamily: Platform.OS === 'android' ? 'normal' : 'Avenir',
-      fontWeight: 'bold',
+      fontWeight: 'bold'
     },
     removeAllText: 'Remove all',
     showRemoveAll: false,
@@ -244,31 +302,34 @@ class SectionedMultiSelect extends PureComponent {
 
   constructor(props) {
     super(props)
-    this.iconLoaded = false
-    if (props.iconRenderer) {
-      this.Icon = props.iconRenderer
-      this.iconLoaded = true
-    } else {
-      this.Icon = require('react-native-vector-icons/MaterialIcons').default
-      this.iconLoaded = true
 
+    if (!props.IconRenderer) {
+      throw new Error(
+        'react-native-sectioned-multi-select: You must supply an IconRenderer prop.\nE.g import Icon from "react-native-vector-icons/MaterialIcons"\n<SectionedMultiSelect IconRenderer={Icon}/>'
+      )
     }
+
+    this.IconRenderer = props.IconRenderer
 
     this.state = {
       selector: false,
       searchTerm: '',
       highlightedChildren: [],
       styles: StyleSheet.flatten([defaultStyles, props.styles]),
-      colors: StyleSheet.flatten([defaultColors, props.colors]),
+      colors: StyleSheet.flatten([defaultColors, props.colors])
     }
   }
 
   componentDidUpdate(prevProps) {
     if (!isEqual(prevProps.styles, this.props.styles)) {
-      this.setState({ styles: StyleSheet.flatten([defaultStyles, this.props.styles]) })
+      this.setState({
+        styles: StyleSheet.flatten([defaultStyles, this.props.styles])
+      })
     }
     if (!isEqual(prevProps.colors, this.props.colors)) {
-      this.setState({ colors: StyleSheet.flatten([defaultColors, this.props.colors]) })
+      this.setState({
+        colors: StyleSheet.flatten([defaultColors, this.props.colors])
+      })
     }
   }
 
@@ -302,7 +363,10 @@ class SectionedMultiSelect extends PureComponent {
     const { uniqueKey } = this.props
     array.reduce((prev, curr) => {
       toSplice.includes(curr[uniqueKey]) &&
-        toSplice.splice(toSplice.findIndex(el => el === curr[uniqueKey]), 1)
+        toSplice.splice(
+          toSplice.findIndex((el) => el === curr[uniqueKey]),
+          1
+        )
     }, {})
     return toSplice
   }
@@ -316,7 +380,7 @@ class SectionedMultiSelect extends PureComponent {
       displayKey,
       alwaysShowSelectText,
       renderSelectText,
-      selectLabelNumberOfLines,
+      selectLabelNumberOfLines
     } = this.props
     const { colors, styles } = this.state
     let customSelect = null
@@ -351,20 +415,17 @@ class SectionedMultiSelect extends PureComponent {
           {
             flex: 1,
             fontSize: 16,
-            color: colors.selectToggleTextColor,
+            color: colors.selectToggleTextColor
           },
-          styles.selectToggleText,
-        ]}
-      >
+          styles.selectToggleText
+        ]}>
         {label}
       </Text>
     )
   }
 
   _filterItems = (searchTerm) => {
-    const {
-      items, subKey, uniqueKey, displayKey, filterItems,
-    } = this.props
+    const { items, subKey, uniqueKey, displayKey, filterItems } = this.props
 
     if (filterItems) {
       return filterItems(searchTerm, items, this.props)
@@ -391,7 +452,7 @@ class SectionedMultiSelect extends PureComponent {
               newItem[subKey] = [...newItem[subKey], sub]
               newFilteredItems = this.rejectProp(
                 filteredItems,
-                singleItem => item[uniqueKey] !== singleItem[uniqueKey],
+                (singleItem) => item[uniqueKey] !== singleItem[uniqueKey]
               )
               newFilteredItems.push(newItem)
               filteredItems = newFilteredItems
@@ -409,10 +470,13 @@ class SectionedMultiSelect extends PureComponent {
       selectedItems,
       onSelectedItemsChange,
       highlightChildren,
-      onSelectedItemObjectsChange,
+      onSelectedItemObjectsChange
     } = this.props
 
-    const newItems = this.rejectProp(selectedItems, singleItem => item[uniqueKey] !== singleItem)
+    const newItems = this.rejectProp(
+      selectedItems,
+      (singleItem) => item[uniqueKey] !== singleItem
+    )
 
     highlightChildren && this._unHighlightChildren(item[uniqueKey])
     onSelectedItemObjectsChange && this._broadcastItemObjects(newItems)
@@ -436,7 +500,7 @@ class SectionedMultiSelect extends PureComponent {
       subKey,
       onSelectedItemsChange,
       onSelectedItemObjectsChange,
-      readOnlyHeadings,
+      readOnlyHeadings
     } = this.props
 
     let newItems = []
@@ -486,7 +550,7 @@ class SectionedMultiSelect extends PureComponent {
     const { onToggleSelector } = this.props
     const newState = !this.state.selector
     this.setState({
-      selector: newState,
+      selector: newState
     })
     onToggleSelector && onToggleSelector(newState)
   }
@@ -495,7 +559,7 @@ class SectionedMultiSelect extends PureComponent {
     const { onToggleSelector } = this.props
     this.setState({
       selector: false,
-      searchTerm: '',
+      searchTerm: ''
     })
     onToggleSelector && onToggleSelector(false)
   }
@@ -528,13 +592,14 @@ class SectionedMultiSelect extends PureComponent {
       onSelectedItemsChange,
       selectChildren,
       highlightChildren,
-      onSelectedItemObjectsChange,
+      onSelectedItemObjectsChange
     } = this.props
 
     if (single) {
       this._submitSelection()
       onSelectedItemsChange([item[uniqueKey]])
-      onSelectedItemObjectsChange && this._broadcastItemObjects([item[uniqueKey]])
+      onSelectedItemObjectsChange &&
+        this._broadcastItemObjects([item[uniqueKey]])
     } else {
       const selected = this._itemSelected(item)
       let newItems = []
@@ -543,15 +608,27 @@ class SectionedMultiSelect extends PureComponent {
           if (selectChildren) {
             newItems = [...this._rejectChildren(item[uniqueKey])]
 
-            newItems = this.rejectProp(newItems, singleItem => item[uniqueKey] !== singleItem)
+            newItems = this.rejectProp(
+              newItems,
+              (singleItem) => item[uniqueKey] !== singleItem
+            )
           } else if (highlightChildren) {
             this._unHighlightChildren(item[uniqueKey])
-            newItems = this.rejectProp(selectedItems, singleItem => item[uniqueKey] !== singleItem)
+            newItems = this.rejectProp(
+              selectedItems,
+              (singleItem) => item[uniqueKey] !== singleItem
+            )
           } else {
-            newItems = this.rejectProp(selectedItems, singleItem => item[uniqueKey] !== singleItem)
+            newItems = this.rejectProp(
+              selectedItems,
+              (singleItem) => item[uniqueKey] !== singleItem
+            )
           }
         } else {
-          newItems = this.rejectProp(selectedItems, singleItem => item[uniqueKey] !== singleItem)
+          newItems = this.rejectProp(
+            selectedItems,
+            (singleItem) => item[uniqueKey] !== singleItem
+          )
         }
       } else {
         newItems = [...selectedItems, item[uniqueKey]]
@@ -584,7 +661,8 @@ class SectionedMultiSelect extends PureComponent {
     for (; i < items.length; i += 1) {
       if (items[i][uniqueKey] === id && Array.isArray(items[i][subKey])) {
         items[i][subKey].forEach((sub) => {
-          !highlighted.includes(sub[uniqueKey]) && highlighted.push(sub[uniqueKey])
+          !highlighted.includes(sub[uniqueKey]) &&
+            highlighted.push(sub[uniqueKey])
         })
       }
     }
@@ -596,7 +674,7 @@ class SectionedMultiSelect extends PureComponent {
     const { highlightedChildren } = this.state
     const highlighted = [...highlightedChildren]
 
-    const array = items.filter(item => item[uniqueKey] === id)
+    const array = items.filter((item) => item[uniqueKey] === id)
 
     if (!array['0']) {
       return
@@ -611,16 +689,15 @@ class SectionedMultiSelect extends PureComponent {
   }
 
   _selectChildren = (id) => {
-    const {
-      items, selectedItems, uniqueKey, subKey,
-    } = this.props
+    const { items, selectedItems, uniqueKey, subKey } = this.props
     if (!items) return
     let i = 0
     const selected = []
     for (; i < items.length; i += 1) {
       if (items[i][uniqueKey] === id && Array.isArray(items[i][subKey])) {
         items[i][subKey].forEach((sub) => {
-          !selectedItems.includes(sub[uniqueKey]) && selected.push(sub[uniqueKey])
+          !selectedItems.includes(sub[uniqueKey]) &&
+            selected.push(sub[uniqueKey])
         })
       }
     }
@@ -631,10 +708,8 @@ class SectionedMultiSelect extends PureComponent {
   }
 
   _rejectChildren = (id) => {
-    const {
-      items, selectedItems, uniqueKey, subKey,
-    } = this.props
-    const arrayOfChildren = items.filter(item => item[uniqueKey] === id)
+    const { items, selectedItems, uniqueKey, subKey } = this.props
+    const arrayOfChildren = items.filter((item) => item[uniqueKey] === id)
     const selected = [...selectedItems]
     if (!arrayOfChildren['0']) {
       return
@@ -643,7 +718,10 @@ class SectionedMultiSelect extends PureComponent {
       return
     }
 
-    const newSelected = this.reduceSelected(arrayOfChildren['0'][subKey], selected)
+    const newSelected = this.reduceSelected(
+      arrayOfChildren['0'][subKey],
+      selected
+    )
 
     // update state for SubRowItem component should update checks
     this._unHighlightChildren(id)
@@ -651,13 +729,20 @@ class SectionedMultiSelect extends PureComponent {
   }
 
   _toggleChildren = (item) => {
-    const { uniqueKey, onSelectedItemsChange, onSelectedItemObjectsChange } = this.props
+    const {
+      uniqueKey,
+      onSelectedItemsChange,
+      onSelectedItemObjectsChange
+    } = this.props
 
     const selected = this._itemSelected(item)
     let newItems = []
     if (selected) {
       newItems = [...this._rejectChildren(item[uniqueKey])]
-      newItems = this.rejectProp(newItems, singleItem => item[uniqueKey] !== singleItem)
+      newItems = this.rejectProp(
+        newItems,
+        (singleItem) => item[uniqueKey] !== singleItem
+      )
     } else {
       newItems = [...newItems, ...this._selectChildren(item[uniqueKey])]
     }
@@ -683,7 +768,12 @@ class SectionedMultiSelect extends PureComponent {
   _customChipsRenderer = () => {
     const { styles, colors } = this.state
     const {
-      displayKey, items, selectedItems, subKey, uniqueKey, customChipsRenderer,
+      displayKey,
+      items,
+      selectedItems,
+      subKey,
+      uniqueKey,
+      customChipsRenderer
     } = this.props
 
     return (
@@ -695,7 +785,7 @@ class SectionedMultiSelect extends PureComponent {
         selectedItems,
         styles,
         subKey,
-        uniqueKey,
+        uniqueKey
       })
     )
   }
@@ -708,20 +798,22 @@ class SectionedMultiSelect extends PureComponent {
       customChipsRenderer,
       showRemoveAll,
       removeAllText,
-      showChips,
+      showChips
     } = this.props
-    return selectedItems.length > 0 && !single && showChips && !customChipsRenderer ? (
+    return selectedItems.length > 0 &&
+      !single &&
+      showChips &&
+      !customChipsRenderer ? (
       <View
         style={[
           {
             flexWrap: 'wrap',
             alignItems: 'center',
             justifyContent: 'flex-start',
-            flexDirection: 'row',
+            flexDirection: 'row'
           },
-          styles.chipsWrapper,
-        ]}
-      >
+          styles.chipsWrapper
+        ]}>
         {selectedItems.length > 1 && showRemoveAll ? (
           <View
             style={[
@@ -738,30 +830,27 @@ class SectionedMultiSelect extends PureComponent {
                 paddingRight: 10,
                 paddingBottom: 0,
                 borderRadius: 20,
-                borderWidth: 1,
+                borderWidth: 1
               },
-              styles.chipContainer,
-            ]}
-          >
+              styles.chipContainer
+            ]}>
             <TouchableOpacity
               onPress={() => {
                 this._removeAllItems()
               }}
               style={{
                 borderTopRightRadius: 20,
-                borderBottomRightRadius: 20,
-              }}
-            >
+                borderBottomRightRadius: 20
+              }}>
               <Text
                 style={[
                   {
                     color: colors.chipColor,
                     fontSize: 13,
-                    marginRight: 0,
+                    marginRight: 0
                   },
-                  styles.chipText,
-                ]}
-              >
+                  styles.chipText
+                ]}>
                 {removeAllText}
               </Text>
             </TouchableOpacity>
@@ -771,8 +860,10 @@ class SectionedMultiSelect extends PureComponent {
       </View>
     ) : null
   }
+
   _displaySelectedItems = () => {
     const {
+      icons,
       uniqueKey,
       subKey,
       selectedItems,
@@ -780,6 +871,7 @@ class SectionedMultiSelect extends PureComponent {
       chipRemoveIconComponent,
       parentChipsRemoveChildren,
       hideChipRemove,
+      IconRenderer
     } = this.props
     const { styles, colors } = this.state
     return selectedItems.map((singleSelectedItem) => {
@@ -804,28 +896,26 @@ class SectionedMultiSelect extends PureComponent {
               margin: 3,
               paddingTop: 0,
               paddingRight: hideChipRemove ? 10 : 0,
-              paddingBottom: 0,
+              paddingBottom: 0
             },
             styles.chipContainer,
-            isParent && styles.parentChipContainer,
+            isParent && styles.parentChipContainer
           ]}
-          key={item[uniqueKey]}
-        >
+          key={item[uniqueKey]}>
           <Text
             numberOfLines={1}
             style={[
               {
                 color: colors.chipColor,
                 fontSize: 13,
-                marginRight: 0,
+                marginRight: 0
               },
               styles.chipText,
-              isParent && styles.parentChipText,
-            ]}
-          >
+              isParent && styles.parentChipText
+            ]}>
             {item[displayKey]}
           </Text>
-          { !hideChipRemove &&
+          {!hideChipRemove && (
             <TouchableOpacity
               onPress={() => {
                 isParent && parentChipsRemoveChildren
@@ -834,25 +924,24 @@ class SectionedMultiSelect extends PureComponent {
               }}
               style={{
                 borderTopRightRadius: 20,
-                borderBottomRightRadius: 20,
-              }}
-            >
+                borderBottomRightRadius: 20
+              }}>
               {callIfFunction(chipRemoveIconComponent) || (
-                <this.Icon
-                  name="close"
+                <IconRenderer
+                  name={icons.close.name}
+                  size={icons.close.size}
                   style={[
                     {
                       color: colors.chipColor,
-                      fontSize: 16,
                       marginHorizontal: 6,
-                      marginVertical: 7,
+                      marginVertical: 7
                     },
-                    styles.chipIcon,
+                    styles.chipIcon
                   ]}
                 />
               )}
             </TouchableOpacity>
-          }
+          )}
         </View>
       )
     })
@@ -865,9 +954,9 @@ class SectionedMultiSelect extends PureComponent {
           flex: 1,
           height: StyleSheet.hairlineWidth,
           alignSelf: 'stretch',
-          backgroundColor: '#dadada',
+          backgroundColor: '#dadada'
         },
-        this.state.styles.separator,
+        this.state.styles.separator
       ]}
     />
   )
@@ -884,7 +973,7 @@ class SectionedMultiSelect extends PureComponent {
     return (
       <View>
         <RowItem
-          iconRenderer={this.Icon}
+          iconRenderer={this.IconRenderer}
           item={item}
           mergedStyles={styles}
           mergedColors={colors}
@@ -901,14 +990,27 @@ class SectionedMultiSelect extends PureComponent {
     const { modalWithSafeAreaView } = this.props
     const { styles } = this.state
     const Component = modalWithSafeAreaView ? SafeAreaView : View
-    return <Component style={[{ flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' }, styles.modalWrapper]}>{children}</Component>
+    return (
+      <Component
+        style={[
+          { flex: 1, backgroundColor: 'rgba(0,0,0,0.5)' },
+          styles.modalWrapper
+        ]}>
+        {children}
+      </Component>
+    )
   }
   BackdropView = ({ children, ...props }) => {
     const { modalWithTouchable } = this.props
     const Wrapper = modalWithTouchable ? TouchableWithoutFeedback : null
 
-    return Wrapper ? <Wrapper onPress={this._closeSelector}><View {...props} /></Wrapper>
-      : <View {...props} />
+    return Wrapper ? (
+      <Wrapper onPress={this._closeSelector}>
+        <View {...props} />
+      </Wrapper>
+    ) : (
+      <View {...props} />
+    )
   }
 
   // _renderSubItemFlatList = ({ item }) => (
@@ -925,6 +1027,7 @@ class SectionedMultiSelect extends PureComponent {
   render() {
     const {
       items,
+      icons,
       selectedItems,
       uniqueKey,
       confirmText,
@@ -951,12 +1054,15 @@ class SectionedMultiSelect extends PureComponent {
       chipsPosition,
       autoFocus,
       disabled,
-      itemsFlatListProps,
+      itemsFlatListProps
     } = this.props
     const { searchTerm, selector, styles, colors } = this.state
-    const renderItems = searchTerm ? this._filterItems(searchTerm.trim()) : items
+    const renderItems = searchTerm
+      ? this._filterItems(searchTerm.trim())
+      : items
     const confirmFont = confirmFontFamily.fontFamily && confirmFontFamily
-    const searchTextFont = searchTextFontFamily.fontFamily && searchTextFontFamily
+    const searchTextFont =
+      searchTextFontFamily.fontFamily && searchTextFontFamily
     return (
       <View>
         <Modal
@@ -964,156 +1070,167 @@ class SectionedMultiSelect extends PureComponent {
           animationType={modalAnimationType}
           transparent
           visible={selector}
-          onRequestClose={this._closeSelector}
-        >
+          onRequestClose={this._closeSelector}>
           <this.ModalContentWrapper>
             <this.BackdropView
               style={[
                 {
                   ...StyleSheet.absoluteFillObject,
                   zIndex: 0,
-                  flex: 1,
+                  flex: 1
                 },
-                styles.backdrop,
+                styles.backdrop
               ]}
             />
 
-          <View
-            style={[
-              {
-                overflow: 'hidden',
-                marginHorizontal: 18,
-                marginVertical: 26,
-                borderRadius: 6,
-                alignSelf: 'stretch',
-                flex: 1,
-                backgroundColor: 'white',
-              },
-              styles.container,
-            ]}
-          >
-            {headerComponent && callIfFunction(headerComponent)}
-            {!hideSearch && (
-              <View style={[{ flexDirection: 'row', paddingVertical: 5 }, styles.searchBar]}>
-                <View style={styles.center}>
-                  {callIfFunction(searchIconComponent) || (
-                    <this.Icon name="search" size={18} style={{ marginHorizontal: 15 }} />
-                  )}
-                </View>
-                <TextInput
-                  value={this.state.searchTerm}
-                  selectionColor={colors.searchSelectionColor}
-                  onChangeText={searchTerm => this.setState({ searchTerm })}
-                  placeholder={searchPlaceholderText}
-                  autoFocus={autoFocus}
-                  selectTextOnFocus
-                  placeholderTextColor={colors.searchPlaceholderTextColor}
-                  underlineColorAndroid="transparent"
-                  style={[
-                    {
-                      flex: 1,
-                      fontSize: 17,
-                      paddingVertical: 8,
-                    },
-                    searchTextFont,
-                    styles.searchTextInput,
-                  ]}
-                />
-                {searchAdornment && searchAdornment(searchTerm)}
-              </View>
-            )}
-
             <View
-              keyboardShouldPersistTaps="always"
-              style={[{ paddingHorizontal: 12, flex: 1 }, styles.scrollView]}
-            >
-              <View>
-                {loading ? (
-                  callIfFunction(loadingComponent)
-                ) : (
-                  <View>
-                    {!renderItems || (!renderItems.length && !searchTerm)
-                      ? callIfFunction(noItemsComponent)
-                      : null}
-                    {items && renderItems && renderItems.length ? (
-                      <View>
-                        <FlatList
-                          keyboardShouldPersistTaps="always"
-                          removeClippedSubviews
-                          initialNumToRender={15}
-                          data={renderItems}
-                          extraData={selectedItems}
-                          keyExtractor={item => `${item[uniqueKey]}`}
-                          ItemSeparatorComponent={this._renderSeparator}
-                          ListFooterComponent={this._renderFooter}
-                          renderItem={this._renderItemFlatList}
-                          {...itemsFlatListProps}
-                        />
-                      </View>
-                    ) : searchTerm ? (
-                      callIfFunction(noResultsComponent)
-                    ) : null}
-                  </View>
-                )}
-              </View>
-            </View>
-            <View style={{ flexDirection: 'row' }}>
-              {showCancelButton && (
-                <Touchable accessibilityComponentType="button" onPress={this._cancelSelection}>
-                  <View
-                    style={[
-                      {
-                        width: 54,
-                        flex: Platform.OS === 'android' ? 0 : 1,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        paddingVertical: 8,
-                        paddingHorizontal: 16,
-                        borderRadius: 0,
-                        flexDirection: 'row',
-                        backgroundColor: colors.cancel,
-                      },
-                      styles.cancelButton,
-                    ]}
-                  >
-                    {callIfFunction(cancelIconComponent) || (
-                      <this.Icon size={24} name="cancel" style={{ color: 'white' }} />
+              style={[
+                {
+                  overflow: 'hidden',
+                  marginHorizontal: 18,
+                  marginVertical: 26,
+                  borderRadius: 6,
+                  alignSelf: 'stretch',
+                  flex: 1,
+                  backgroundColor: 'white'
+                },
+                styles.container
+              ]}>
+              {headerComponent && callIfFunction(headerComponent)}
+              {!hideSearch && (
+                <View
+                  style={[
+                    { flexDirection: 'row', paddingVertical: 5 },
+                    styles.searchBar
+                  ]}>
+                  <View style={styles.center}>
+                    {callIfFunction(searchIconComponent) || (
+                      <this.IconRenderer
+                        name={icons.search.name}
+                        size={icons.search.size}
+                        style={{ marginHorizontal: 15 }}
+                      />
                     )}
                   </View>
-                </Touchable>
-              )}
-              {!hideConfirm && (
-                <Touchable
-                  accessibilityComponentType="button"
-                  onPress={this._submitSelection}
-                  style={{ flex: 1 }}
-                >
-                  <View
+                  <TextInput
+                    value={this.state.searchTerm}
+                    selectionColor={colors.searchSelectionColor}
+                    onChangeText={(searchTerm) => this.setState({ searchTerm })}
+                    placeholder={searchPlaceholderText}
+                    autoFocus={autoFocus}
+                    selectTextOnFocus
+                    placeholderTextColor={colors.searchPlaceholderTextColor}
+                    underlineColorAndroid="transparent"
                     style={[
                       {
-                        flex: Platform.OS === 'android' ? 1 : 0,
-                        alignItems: 'center',
-                        justifyContent: 'center',
-                        paddingVertical: 8,
-                        paddingHorizontal: 16,
-                        borderRadius: 0,
-                        flexDirection: 'row',
-                        backgroundColor: colors.primary,
+                        flex: 1,
+                        fontSize: 17,
+                        paddingVertical: 8
                       },
-                      styles.button,
+                      searchTextFont,
+                      styles.searchTextInput
                     ]}
-                  >
-                    <Text
-                      style={[{ fontSize: 18, color: '#ffffff' }, confirmFont, styles.confirmText]}
-                    >
-                      {confirmText}
-                    </Text>
-                  </View>
-                </Touchable>
+                  />
+                  {searchAdornment && searchAdornment(searchTerm)}
+                </View>
               )}
+
+              <View
+                keyboardShouldPersistTaps="always"
+                style={[{ paddingHorizontal: 12, flex: 1 }, styles.scrollView]}>
+                <View>
+                  {loading ? (
+                    callIfFunction(loadingComponent)
+                  ) : (
+                    <View>
+                      {!renderItems || (!renderItems.length && !searchTerm)
+                        ? callIfFunction(noItemsComponent)
+                        : null}
+                      {items && renderItems && renderItems.length ? (
+                        <View>
+                          <FlatList
+                            keyboardShouldPersistTaps="always"
+                            removeClippedSubviews
+                            initialNumToRender={15}
+                            data={renderItems}
+                            extraData={selectedItems}
+                            keyExtractor={(item) => `${item[uniqueKey]}`}
+                            ItemSeparatorComponent={this._renderSeparator}
+                            ListFooterComponent={this._renderFooter}
+                            renderItem={this._renderItemFlatList}
+                            {...itemsFlatListProps}
+                          />
+                        </View>
+                      ) : searchTerm ? (
+                        callIfFunction(noResultsComponent)
+                      ) : null}
+                    </View>
+                  )}
+                </View>
+              </View>
+              <View style={{ flexDirection: 'row' }}>
+                {showCancelButton && (
+                  <Touchable
+                    accessibilityComponentType="button"
+                    onPress={this._cancelSelection}>
+                    <View
+                      style={[
+                        {
+                          width: 54,
+                          flex: Platform.OS === 'android' ? 0 : 1,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          paddingVertical: 8,
+                          paddingHorizontal: 16,
+                          borderRadius: 0,
+                          flexDirection: 'row',
+                          backgroundColor: colors.cancel
+                        },
+                        styles.cancelButton
+                      ]}>
+                      {callIfFunction(cancelIconComponent) || (
+                        <this.IconRenderer
+                          size={icons.cancel.size}
+                          name={icons.cancel.name}
+                          style={{ color: 'white' }}
+                        />
+                      )}
+                    </View>
+                  </Touchable>
+                )}
+                {!hideConfirm && (
+                  <Touchable
+                    accessibilityComponentType="button"
+                    onPress={this._submitSelection}
+                    style={{ flex: 1 }}>
+                    <View
+                      style={[
+                        {
+                          flex: Platform.OS === 'android' ? 1 : 0,
+                          alignItems: 'center',
+                          justifyContent: 'center',
+                          paddingVertical: 8,
+                          paddingHorizontal: 16,
+                          borderRadius: 0,
+                          flexDirection: 'row',
+                          backgroundColor: colors.primary
+                        },
+                        styles.button
+                      ]}>
+                      <Text
+                        style={[
+                          { fontSize: 18, color: '#ffffff' },
+                          confirmFont,
+                          styles.confirmText
+                        ]}>
+                        {confirmText}
+                      </Text>
+                    </View>
+                  </Touchable>
+                )}
+              </View>
+              {stickyFooterComponent && callIfFunction(stickyFooterComponent)}
             </View>
-            {stickyFooterComponent && callIfFunction(stickyFooterComponent)}
-          </View>
           </this.ModalContentWrapper>
         </Modal>
         {chipsPosition === 'top' && this._renderChips()}
@@ -1121,21 +1238,19 @@ class SectionedMultiSelect extends PureComponent {
         {!hideSelect && (
           <TouchableWithoutFeedback
             onPress={this._toggleSelector}
-            disabled={this.state.selector || disabled}
-          >
+            disabled={this.state.selector || disabled}>
             <View
               style={[
                 {
                   flexWrap: 'wrap',
                   flexDirection: 'row',
-                  alignItems: 'center',
+                  alignItems: 'center'
                 },
-                styles.selectToggle,
-              ]}
-            >
+                styles.selectToggle
+              ]}>
               {this._getSelectLabel()}
               {callIfFunction(selectToggleIconComponent) || (
-                <this.Icon
+                <this.IconRenderer
                   size={24}
                   name="keyboard-arrow-down"
                   style={{ color: colors.selectToggleTextColor }}

--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -237,15 +237,19 @@ class SectionedMultiSelect extends PureComponent {
       },
       arrowUp: {
         name: 'keyboard-arrow-up',
-        size: 16
+        size: 22
       },
       arrowDown: {
         name: 'keyboard-arrow-down',
-        size: 16
+        size: 22
+      },
+      selectArrowDown: {
+        name: 'keyboard-arrow-down',
+        size: 24
       },
       close: {
         name: 'close',
-        size: 22
+        size: 16
       },
       check: {
         name: 'check',
@@ -253,7 +257,7 @@ class SectionedMultiSelect extends PureComponent {
       },
       cancel: {
         name: 'cancel',
-        size: 16
+        size: 18
       }
     },
     itemFontFamily: {
@@ -928,8 +932,6 @@ class SectionedMultiSelect extends PureComponent {
               }}>
               {callIfFunction(chipRemoveIconComponent) || (
                 <IconRenderer
-                  name={icons.close.name}
-                  size={icons.close.size}
                   style={[
                     {
                       color: colors.chipColor,
@@ -938,6 +940,7 @@ class SectionedMultiSelect extends PureComponent {
                     },
                     styles.chipIcon
                   ]}
+                  {...icons.close}
                 />
               )}
             </TouchableOpacity>
@@ -1106,9 +1109,8 @@ class SectionedMultiSelect extends PureComponent {
                   <View style={styles.center}>
                     {callIfFunction(searchIconComponent) || (
                       <this.IconRenderer
-                        name={icons.search.name}
-                        size={icons.search.size}
                         style={{ marginHorizontal: 15 }}
+                        {...icons.search}
                       />
                     )}
                   </View>
@@ -1190,9 +1192,8 @@ class SectionedMultiSelect extends PureComponent {
                       ]}>
                       {callIfFunction(cancelIconComponent) || (
                         <this.IconRenderer
-                          size={icons.cancel.size}
-                          name={icons.cancel.name}
                           style={{ color: 'white' }}
+                          {...icons.cancel}
                         />
                       )}
                     </View>
@@ -1251,9 +1252,8 @@ class SectionedMultiSelect extends PureComponent {
               {this._getSelectLabel()}
               {callIfFunction(selectToggleIconComponent) || (
                 <this.IconRenderer
-                  size={24}
-                  name="keyboard-arrow-down"
                   style={{ color: colors.selectToggleTextColor }}
+                  {...icons.selectArrowDown}
                 />
               )}
             </View>

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "eslint-plugin-react": "^7.5.1"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.0",
-    "react-native-vector-icons": "^4.1.1"
+    "prop-types": "^15.6.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION


### Fixed

- 0.7.8 introduced a bug with an attempted fix of the iconRenderer. This update addresses that and icons in general.

### Added

- the `icons` prop is an object that maps the names and sizes used for the icons. In conjunction with `IconRenderer` you can now easily switch out the icon library. See Icons section of Readme.

### Changed

- BREAKING: `IconRenderer` is now required (also note the casing change). The lib no longer relies on `react-native-vector-icons`. For the default Material Icons icon set, you must import Icon from `react-native-vector-icons/MaterialIcons` yourself, and pass that to the`IconRenderer` prop. See Icons section of Readme.
