### PR TITLE
fix: Android setLayoutAnimationEnabledExperimental on test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 0.8.1 - 2020-11-03
+
+### Fixed
+
+ - React NAtive's UIManager.setLayoutAnimationEnabledExperimental causing tests fail. This version has fix for it. \n Details:
+ ```sh
+ TypeError: _reactNative.UIManager.setLayoutAnimationEnabledExperimental is not a function
+ ```
+
 ## 0.8.0 - 2020-10-01
 
 ### Fixed

--- a/lib/components/RowItem.js
+++ b/lib/components/RowItem.js
@@ -19,7 +19,7 @@ class RowItem extends Component {
     super(props)
 
     if (Platform.OS === 'android') {
-      UIManager.setLayoutAnimationEnabledExperimental(true)
+      UIManager.setLayoutAnimationEnabledExperimental && UIManager.setLayoutAnimationEnabledExperimental(true)
     }
     this.state = {
       showSubCategories: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sectioned-multi-select",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sectioned-multi-select",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "a multi (or single) select component with support for sub categories, search, chips.",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
# The Problem:

Lack of mocking for UIManager causes error during test:
```sh
TypeError: _reactNative.UIManager.setLayoutAnimationEnabledExperimental is not a function

      at new RowItem (node_modules/react-native-sectioned-multi-select/lib/components/RowItem.js:23:17)
      at constructClassInstance (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:3629:18)
      at updateClassComponent (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:7558:5)
      at beginWork$1 (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:9043:16)
      at performUnitOfWork (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:12649:12)
      at workLoopSync (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:12622:22)
      at callback (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:12333:9)
      at eventHandler (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1825:24)
      at Scheduler_runWithPriority (node_modules/scheduler/cjs/scheduler.development.js:653:12)
      at runWithPriority (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:1775:10)
```

## Cause of the error:
`setLayoutAnimationEnabledExperimental` invoked directly,
https://github.com/renrizzolo/react-native-sectioned-multi-select/blob/d33fcb1a9a00a7d80735badedfd63bed089bfe68/lib/components/RowItem.js#L22

## Solution
Facebook warn to use `setLayoutAnimationEnabledExperimental` with caution and check the existence:
https://github.com/facebook/react-native/blob/master/Libraries/LayoutAnimation/LayoutAnimation.js#L98-L100

With this PR I follow the Facebook suggetion and add the necessary checking.

It also eliminate the issue I created earlier:
https://github.com/renrizzolo/react-native-sectioned-multi-select/issues/218