### PR TITLE
TypeError: undefined is not an object (evaluating 'item[subKey]')

### DIFF
--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -880,9 +880,10 @@ class SectionedMultiSelect extends PureComponent {
     const { styles, colors } = this.state
     return selectedItems.map((singleSelectedItem) => {
       const item = this._findItem(singleSelectedItem)
-      const isParent = subKey && item[subKey] && item[subKey].length
-
+      
       if (!item || !item[displayKey]) return null
+      
+      const isParent = subKey && item[subKey] && item[subKey].length
 
       return (
         <View


### PR DESCRIPTION
TypeError: undefined is not an object (evaluating 'item[subKey]')

It appears when 'items' are not populated before initial render thus selectedItem are not found. Works well for non sub lists as the item check is not performed. Fix is simple to put item null check before accessing it. 

![image](https://user-images.githubusercontent.com/154998/118305163-38f55c00-b505-11eb-82e5-8cc65d977eda.png)
