### PR TITLE
Add Various Accessibility Properties

### DIFF
--- a/lib/components/RowItem.js
+++ b/lib/components/RowItem.js
@@ -216,6 +216,8 @@ class RowItem extends Component {
       subItemsFlatListProps
     } = this.props
     const hasDropDown = item[subKey] && item[subKey].length > 0 && showDropDowns
+    const itemSelected = this._itemSelected(item)
+    const showSubCategoryDropDown = this._showSubCategoryDropDown()
 
     return (
       <View>
@@ -230,6 +232,8 @@ class RowItem extends Component {
           <TouchableOpacity
             disabled={(readOnlyHeadings && !showDropDowns) || item.disabled}
             onPress={this._dropDownOrToggle}
+            accessibilityState={{ selected: itemSelected }}
+            accessibilityRole={readOnlyHeadings ? 'header' : 'menuitem'}
             style={[
               {
                 flex: 1,
@@ -239,7 +243,7 @@ class RowItem extends Component {
                 paddingVertical: 6
               },
               mergedStyles.item,
-              this._itemSelected(item) && mergedStyles.selectedItem
+              itemSelected && mergedStyles.selectedItem
             ]}
           >
             {selectedIconOnLeft && this._renderSelectedIcon()}
@@ -280,9 +284,10 @@ class RowItem extends Component {
                 },
                 mergedStyles.toggleIcon
               ]}
+              accessibilityState={{ expanded: showSubCategoryDropDown }}
               onPress={this._toggleDropDown}
             >
-              {this._showSubCategoryDropDown() ? (
+              {showSubCategoryDropDown ? (
                 <View>
                   {callIfFunction(dropDownToggleIconUpComponent) || (
                     <Icon
@@ -308,7 +313,7 @@ class RowItem extends Component {
             </TouchableOpacity>
           )}
         </View>
-        {item[subKey] && this._showSubCategoryDropDown() && (
+        {item[subKey] && showSubCategoryDropDown && (
           <FlatList
             keyExtractor={(i) => `${i[uniqueKey]}`}
             data={item[subKey]}

--- a/lib/components/RowSubItem.js
+++ b/lib/components/RowSubItem.js
@@ -131,6 +131,8 @@ class RowSubItem extends Component {
         <TouchableOpacity
           disabled={highlightChild || subItem.disabled}
           onPress={this._toggleItem}
+          accessibilityState={{ selected: itemSelected }}
+          accessibilityRole="menuitem"
           style={[
             {
               flex: 1,

--- a/lib/sectioned-multi-select.js
+++ b/lib/sectioned-multi-select.js
@@ -1292,7 +1292,8 @@ class SectionedMultiSelect extends PureComponent {
           <TouchableWithoutFeedback
             onPress={this._toggleSelector}
             disabled={this.state.selector || disabled}
-          >
+            accessibilityRole="combobox"
+            >
             <View
               style={[
                 {


### PR DESCRIPTION
My company was testing our mobile app for accessibility with VoiceOver, three issues we noticed that are seemingly unsolvable in the package's current state/available properties were

1. When readOnlyHeadings={true} the headings do say "dimmed" which is fine however they should really be identified as a "header" as that's what it's trying to achieve instead of being read aloud like they are still selectable items.
2. Selectable items aren't read as "selected" by the screen reader and the user can't know what selections they have made. By adding accessibilityState={{ selected: itemSelected }} the screen reader now says "Selected, [Item name]" when an item is selected.
3. The select component that's rendered is trying to act as a combobox, and therefore the role should be combobox.

Please consider my changes, thank you for taking the time to review this pull request.